### PR TITLE
Disable MD5 and SHA1 in push-container-image stage

### DIFF
--- a/tests/step_implementers/sign_container_image/test_curl_push.py
+++ b/tests/step_implementers/sign_container_image/test_curl_push.py
@@ -91,12 +91,10 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
 
-            # # Expected results
+            # Expected results
             expected_step_result = StepResult(step_name='sign-container-image', sub_step_name='CurlPush',
                                               sub_step_implementer_name='CurlPush')
             expected_step_result.add_artifact(name='container-image-signature-url', value=f'https://sigserver/signatures/{container_image_signature_name}')
-            # expected_step_result.add_artifact(name='container-image-signature-file-sha1', value=None)
-            # expected_step_result.add_artifact(name='container-image-signature-file-md5', value=None)
 
             self.assertEqual(expected_step_result.get_step_result_dict(), result.get_step_result_dict())
             curl_mock.assert_called_once_with(


### PR DESCRIPTION
Allow to toggle if we want to use MD5 and/or SHA1 for signature files. By default we use a FIPS-compliant code path.