### PR TITLE
Add `tls-verify` toggles to step runner. Add force push of git tags.

### DIFF
--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -299,10 +299,6 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             that are required before running the step.
         """
 
-    @staticmethod
-    def _str2bool(var):
-        return var.lower() in ("true", "yes")
-
     @abstractmethod
     def _run_step(self):
         """Runs the step implemented by this StepImplementer.

--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -299,6 +299,10 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             that are required before running the step.
         """
 
+    @staticmethod
+    def _str2bool(var):
+        return var.lower() in ("true", "yes")
+
     @abstractmethod
     def _run_step(self):
         """Runs the step implemented by this StepImplementer.

--- a/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
@@ -31,6 +31,7 @@ Result Artifact Key | Description
 """
 import os
 import sys
+from distutils import util
 from pathlib import Path
 
 import sh
@@ -145,7 +146,7 @@ class Buildah(StepImplementer):
             container_registries_login(
                 registries=self.get_value('container-registries'),
                 containers_config_auth_file=containers_config_auth_file,
-                containers_config_tls_verify=self._str2bool(tls_verify)
+                containers_config_tls_verify=util.strtobool(tls_verify)
             )
 
             # perform build

--- a/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
@@ -46,6 +46,7 @@ Result Artifact Key                     | Description
 """
 import os
 import sys
+from distutils import util
 from pathlib import Path
 
 import sh
@@ -138,7 +139,7 @@ class Skopeo(StepImplementer):
             container_registries_login(
                 registries=self.get_value('container-registries'),
                 containers_config_auth_file=containers_config_auth_file,
-                containers_config_tls_verify=self._str2bool(dest_tls_verify)
+                containers_config_tls_verify=util.strtobool(dest_tls_verify)
             )
 
             # push image

--- a/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
@@ -122,6 +122,7 @@ class Skopeo(StepImplementer):
         organization = self.get_value('organization')
         image_tar_file = self.get_value('image-tar-file')
         destination_url = self.get_value('destination-url')
+        dest_tls_verify = self.get_value('dest-tls-verify')
 
         image_registry_uri = destination_url
         image_registry_organization = organization
@@ -136,7 +137,8 @@ class Skopeo(StepImplementer):
             containers_config_auth_file = self.get_value('containers-config-auth-file')
             container_registries_login(
                 registries=self.get_value('container-registries'),
-                containers_config_auth_file=containers_config_auth_file
+                containers_config_auth_file=containers_config_auth_file,
+                containers_config_tls_verify=self._str2bool(dest_tls_verify)
             )
 
             # push image

--- a/src/ploigos_step_runner/utils/containers.py
+++ b/src/ploigos_step_runner/utils/containers.py
@@ -7,7 +7,10 @@ import sh
 from ploigos_step_runner.config.config_value import ConfigValue
 
 
-def container_registries_login(registries, containers_config_auth_file=None): #pylint: disable=too-many-branches
+def container_registries_login(  #pylint: disable=too-many-branches
+    registries,
+    containers_config_auth_file=None,
+    containers_config_tls_verify=True):
     """Logs into one or more container registries.
 
     Requires one of the following to be installed to do the authentication:
@@ -102,10 +105,13 @@ def container_registries_login(registries, containers_config_auth_file=None): #p
             else:
                 registry_uri = registry_key
 
-            if 'tls-verify' in registry_conf:
-                registry_tls_verify = registry_conf['tls-verify']
+            if containers_config_tls_verify is False:
+                registry_tls_verify = False
             else:
-                registry_tls_verify = True
+                if 'tls-verify' in registry_conf:
+                    registry_tls_verify = registry_conf['tls-verify']
+                else:
+                    registry_tls_verify = True
 
             container_registry_login(
                 container_registry_uri=registry_uri,
@@ -129,10 +135,13 @@ def container_registries_login(registries, containers_config_auth_file=None): #p
                 f"Configuration for container registry " \
                 f"must specify a 'password': {registry_conf}"
 
-            if 'tls-verify' in registry_conf:
-                registry_tls_verify = registry_conf['tls-verify']
+            if containers_config_tls_verify is False:
+                registry_tls_verify = False
             else:
-                registry_tls_verify = True
+                if 'tls-verify' in registry_conf:
+                    registry_tls_verify = registry_conf['tls-verify']
+                else:
+                    registry_tls_verify = True
 
             container_registry_login(
                 container_registry_uri=registry_conf['uri'],

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -39,7 +39,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             'containers-config-auth-file': os.path.join(Path.home(), '.buildah-auth.json'),
             'imagespecfile': 'Dockerfile',
             'context': '.',
-            'tlsverify': 'true',
+            'tls-verify': 'true',
             'format': 'oci'
         }
         self.assertEqual(defaults, expected_defaults)
@@ -50,7 +50,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             'containers-config-auth-file',
             'imagespecfile',
             'context',
-            'tlsverify',
+            'tls-verify',
             'format',
             'service-name',
             'application-name'
@@ -69,7 +69,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tlsverify': 'true',
+                'tls-verify': 'true',
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -142,7 +142,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tlsverify': 'true',
+                'tls-verify': 'true',
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -208,7 +208,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tlsverify': 'true',
+                'tls-verify': 'true',
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -323,7 +323,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': image_spec_file,
                 'context': temp_dir.path,
-                'tlsverify': 'true',
+                'tls-verify': 'true',
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -378,7 +378,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tlsverify': 'true',
+                'tl-sverify': 'true',
                 'format': 'oci',
                 'service-name': service_name,
                 'application-name': application_name

--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -36,6 +36,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     def test_step_implementer_config_defaults(self):
         actual_defaults = Maven.step_implementer_config_defaults()
         expected_defaults = {
+            'tls-verify': True
         }
         self.assertEqual(expected_defaults, actual_defaults)
 
@@ -182,3 +183,67 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 re.DOTALL
             ))
             self.assertEqual(result.artifacts, expected_step_result.artifacts)
+
+    @patch('sh.mvn', create=True)
+    def test_run_step_tls_verify_false(self, mvn_mock):
+        with TempDirectory() as temp_dir:
+            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
+            results_file_name = 'step-runner-results.yml'
+            work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            step_config = {
+                'maven-push-artifact-repo-url': 'pass',
+                'maven-push-artifact-repo-id': 'pass',
+                'tls-verify': False
+            }
+
+            # Previous (fake) results
+            package_artifacts = [{
+                'path': 'test-path',
+                'group-id': 'test-group-id',
+                'artifact-id': 'test-artifact-id',
+                'package-type': 'test-package-type'
+            }]
+            artifact_config = {
+                'package-artifacts': {'value': package_artifacts},
+                'version': {'value': 'test-version'}
+            }
+            self.setup_previous_result(work_dir_path, artifact_config)
+
+            # Actual results
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='push-artifacts',
+                implementer='Maven',
+                results_dir_path=results_dir_path,
+                results_file_name=results_file_name,
+                work_dir_path=work_dir_path,
+            )
+            result = step_implementer._run_step()
+
+            # Expected results
+            push_artifacts = [{
+                'artifact-id': 'test-artifact-id',
+                'group-id': 'test-group-id',
+                'version': 'test-version',
+                'path': 'test-path',
+                'packaging': 'test-package-type',
+            }]
+            expected_step_result = StepResult(
+                step_name='push-artifacts',
+                sub_step_name='Maven',
+                sub_step_implementer_name='Maven'
+            )
+            expected_step_result.add_artifact(name='push-artifacts', value=push_artifacts)
+            mvn_output_file_path = os.path.join(
+                work_dir_path,
+                'push-artifacts',
+                'mvn_test_output.txt'
+            )
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from 'mvn install'.",
+                name='maven-output',
+                value=mvn_output_file_path
+            )
+            self.assertEqual(expected_step_result.get_step_result_dict(), result.get_step_result_dict())
+

--- a/tests/utils/test_containers.py
+++ b/tests/utils/test_containers.py
@@ -740,3 +740,73 @@ class TestContainerRegistriesLogin(BaseTestCase):
         container_registries_login(registries)
 
         container_registry_login.assert_not_called()
+
+
+class TestContainerRegistriesLoginForceOverrideTlsVerifyLogin(BaseTestCase):
+    @patch('ploigos_step_runner.utils.containers.container_registry_login')
+    def test_dict_of_dicts(self, container_registry_login_mock):
+        registries = {
+            'registry.redhat.io': {
+                'username': 'hello1@world.xyz',
+                'password': 'nope1'
+            },
+            'registry.internal.example.xyz': {
+                'username': 'hello2@example.xyz',
+                'password': 'nope2'
+            }
+        }
+
+        container_registries_login(registries, containers_config_tls_verify=False)
+
+        calls = [
+            call(
+                container_registry_uri='registry.redhat.io',
+                container_registry_username='hello1@world.xyz',
+                container_registry_password='nope1',
+                container_registry_tls_verify=False,
+                containers_config_auth_file=None
+            ),
+            call(
+                container_registry_uri='registry.internal.example.xyz',
+                container_registry_username='hello2@example.xyz',
+                container_registry_password='nope2',
+                container_registry_tls_verify=False,
+                containers_config_auth_file=None
+            )
+        ]
+        container_registry_login_mock.assert_has_calls(calls)
+
+    @patch('ploigos_step_runner.utils.containers.container_registry_login')
+    def test_list_of_dicts(self, container_registry_login_mock):
+        registries = [
+            {
+                'uri': 'registry.redhat.io',
+                'username': 'hello1@world.xyz',
+                'password': 'nope1'
+            },
+            {
+                'uri': 'registry.internal.example.xyz',
+                'username': 'hello2@example.xyz',
+                'password': 'nope2'
+            }
+        ]
+
+        container_registries_login(registries, containers_config_tls_verify=False)
+
+        calls = [
+            call(
+                container_registry_uri='registry.redhat.io',
+                container_registry_username='hello1@world.xyz',
+                container_registry_password='nope1',
+                container_registry_tls_verify=False,
+                containers_config_auth_file=None
+            ),
+            call(
+                container_registry_uri='registry.internal.example.xyz',
+                container_registry_username='hello2@example.xyz',
+                container_registry_password='nope2',
+                container_registry_tls_verify=False,
+                containers_config_auth_file=None
+            )
+        ]
+        container_registry_login_mock.assert_has_calls(calls)


### PR DESCRIPTION
A few toggle changes/additions for pipelines:
- For Maven and other pipeline tools, allow ignoring of TLS Cert errors. Default to validate/verify TLS Certs.
- During deployment phase of the pipeline, sometimes a force push of git tags is needed to prevent Jenkins from failing during that stage. Default to 'False' to allow failure of git tag pushing.
