### PR TITLE
Change type of tls-verify in create image step from string to boolean

### DIFF
--- a/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
@@ -13,7 +13,7 @@ Configuration Key | Required? | Default        | Description
 ------------------|-----------|----------------|-----------
 `imagespecfile`   | True      | `'Dockerfile'` | File defining the container image
 `context`         | True      | `'.'`          | Context to build the container image in
-`tls-verify`      | True      | `'true'`       | Whether to verify TLS when pulling parent images
+`tls-verify`      | True      | `True`       | Whether to verify TLS when pulling parent images
 `format`          | True      | `'oci'`        | format of the built image's manifest and metadata
 `containers-config-auth-file` | True | `'~/.buildah-auth.json'` | \
                                                  Path to the container registry authentication \
@@ -31,7 +31,6 @@ Result Artifact Key | Description
 """
 import os
 import sys
-from distutils import util
 from pathlib import Path
 
 import sh
@@ -49,7 +48,7 @@ DEFAULT_CONFIG = {
     'context': '.',
 
     # Verify TLS Certs?
-    'tls-verify': 'true',
+    'tls-verify': True,
 
     # Format of the produced image
     'format': 'oci'
@@ -146,7 +145,7 @@ class Buildah(StepImplementer):
             container_registries_login(
                 registries=self.get_value('container-registries'),
                 containers_config_auth_file=containers_config_auth_file,
-                containers_config_tls_verify=util.strtobool(tls_verify)
+                containers_config_tls_verify=tls_verify
             )
 
             # perform build
@@ -157,7 +156,7 @@ class Buildah(StepImplementer):
             sh.buildah.bud(  # pylint: disable=no-member
                 '--storage-driver=vfs',
                 '--format=' + self.get_value('format'),
-                '--tls-verify=' + str(tls_verify),
+                '--tls-verify=' + str(tls_verify).lower(),
                 '--layers', '-f', image_spec_file,
                 '-t', tag,
                 '--authfile', containers_config_auth_file,

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -39,7 +39,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             'containers-config-auth-file': os.path.join(Path.home(), '.buildah-auth.json'),
             'imagespecfile': 'Dockerfile',
             'context': '.',
-            'tls-verify': 'true',
+            'tls-verify': True,
             'format': 'oci'
         }
         self.assertEqual(defaults, expected_defaults)
@@ -69,7 +69,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tls-verify': 'true',
+                'tls-verify': True,
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -142,7 +142,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tls-verify': 'true',
+                'tls-verify': True,
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -208,7 +208,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
                 'context': temp_dir.path,
-                'tls-verify': 'true',
+                'tls-verify': True,
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
@@ -323,7 +323,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': image_spec_file,
                 'context': temp_dir.path,
-                'tls-verify': 'true',
+                'tls-verify': True,
                 'format': 'oci',
                 'service-name': 'service-name',
                 'application-name': 'app-name'


### PR DESCRIPTION
`tls-verify` is currently defined as a string (which is cast to a boolean) in _only_ the create_container_image step - this causes a type error when `tls-verify` is specified in the global config, since other steps expect the value to be an actual boolean. This change amends the spec of create_container_image to expect a boolean as well.