### PR TITLE
fix issue #117 - Tests fail when skopeo is not installed on local machine - set create=True for mocking skopeo

### DIFF
--- a/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
+++ b/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
@@ -60,7 +60,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
-    @patch.object(sh, 'skopeo')
+    @patch.object(sh, 'skopeo', create=True)
     def test_run_step_pass(self, skopeo_mock):
         with TempDirectory() as temp_dir:
             results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
@@ -135,7 +135,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 _tee='err'
             )
 
-    @patch.object(sh, 'skopeo')
+    @patch.object(sh, 'skopeo', create=True)
     def test_run_step_fail_run_skopeo(self, skopeo_mock):
         with TempDirectory() as temp_dir:
             results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')


### PR DESCRIPTION
the reason for the error was that the mock wasn't set to create if the command didn't exist.

resolves issue #117 