### PR TITLE
refactor WorkflowResult saving to StepRunner

### DIFF
--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from ploigos_step_runner.config.config_value import ConfigValue
 from ploigos_step_runner.step_result import StepResult
 from ploigos_step_runner.utils.io import TextIOIndenter
-from ploigos_step_runner.workflow_result import WorkflowResult
 
 class DefaultSteps:  # pylint: disable=too-few-public-methods
     """Convenience constants for the default steps used in the default workflow definition.
@@ -42,10 +41,8 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
     Parameters
     ----------
-    results_dir_path : str
-        Path to the directory to write the results of the step to
-    results_file_name : str
-        Name of file to write the results of the step to
+    workflow_result : str
+        TODO doc me
     work_dir_path : str
         Path to the directory to write step working files to
     step_environment_config : dict, optional
@@ -64,20 +61,17 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        results_dir_path,
-        results_file_name,
+        workflow_result,
         work_dir_path,
         config,
         environment=None
     ):
-        self.__results_dir_path = results_dir_path
-        self.__results_file_name = results_file_name
         self.__work_dir_path = work_dir_path
 
         self.__config = config
         self.__environment = environment
 
-        self.__workflow_result = None
+        self.__workflow_result = workflow_result
 
         super().__init__()
 
@@ -158,34 +152,6 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         return defaults_for_env
 
     @property
-    def results_file_path(self):
-        """
-        Get the OS path to the results file.
-        EG:  /tmp/tmpno_qi7np/step-runner-results/step-runner-results.yml
-
-        Returns
-        -------
-        str
-            OS path to the results file.
-        """
-        return os.path.join(self.results_dir_path, self.__results_file_name)
-
-    @property
-    def results_dir_path(self):
-        """
-        Get the OS path to the results folder.
-        If the results folder does not exist, create it.
-        EG:  /tmp/tmpno_qi7np/step-runner-results
-
-        Returns
-        -------
-        str
-            OS path to the results folder.
-        """
-        os.makedirs(self.__results_dir_path, exist_ok=True)
-        return self.__results_dir_path
-
-    @property
     def work_dir_path(self):
         """
         Get the OS path to the working folder.
@@ -260,10 +226,6 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             Object containing a list of dictionary of step results
             from previous steps.
         """
-        if not self.__workflow_result:
-            self.__workflow_result = WorkflowResult.load_from_pickle_file(
-                pickle_filename=self.__workflow_result_pickle_file_path
-            )
         return self.__workflow_result
 
     @staticmethod
@@ -406,25 +368,12 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             step_result.success = False
             step_result.message = str(invalid_error)
 
-        # save the step results
-        self.workflow_result.add_step_result(
-            step_result=step_result
-        )
-        self.workflow_result.write_to_pickle_file(
-            pickle_filename=self.__workflow_result_pickle_file_path
-        )
-        self.workflow_result.write_results_to_yml_file(
-            yml_filename=self.results_file_path
-        )
-
         # print the step run results
         StepImplementer.__print_section_title(
             f"Results - {self.step_name}",
             div_char="-",
             indent=1
         )
-
-        StepImplementer.__print_data('Results File Path', self.results_file_path)
 
         StepImplementer.__print_data('Results', step_result.get_step_result_dict())
 
@@ -591,25 +540,6 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
                 environment=environment
             )
         )
-
-    @property
-    def __workflow_result_pickle_file_path(self):
-        """
-        Get the OS path to the workflow result pickle file.
-        (The 'pickle' file contains the serialized list of step results.)
-        The name of the pickle file is the basename of the results_file_name.
-        EG:
-        If the name of the results_file_name is step-runner-results.yml,
-        then the name of the pickle file is step-runner-results.pkl
-        /tmp/tmp9sau_2j5/step-runner-working/step-runner-results.pkl
-
-        Returns
-        -------
-        str
-           OS path to the workflow pickle (serialized) file.
-        """
-        pickle_filename = os.path.splitext(self.__results_file_name)[0] + '.pkl'
-        return os.path.join(self.work_dir_path, pickle_filename)
 
     def create_working_dir_sub_dir(self, sub_dir_relative_path):
         """

--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -334,9 +334,8 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
         Returns
         -------
-        bool
-            True on step run success.
-            False on step run failure.
+        StepResult
+            Results of running this step.
         """
 
         StepImplementer.__print_section_title(f"Step Start - {self.step_name}")
@@ -431,7 +430,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
         StepImplementer.__print_section_title(f'Step End - {self.step_name}')
 
-        return step_result.success
+        return step_result
 
     def get_value(self, key):
         """Get the value for a given key, either from given configuration or from the result

--- a/src/ploigos_step_runner/step_runner.py
+++ b/src/ploigos_step_runner/step_runner.py
@@ -121,7 +121,10 @@ class StepRunner:
             )
 
             # run the step
-            if not sub_step.run_step():
+            step_result = sub_step.run_step()
+
+            # bail out if one of the sub steps fails
+            if not step_result.success:
                 return False
 
         return True

--- a/src/ploigos_step_runner/step_runner.py
+++ b/src/ploigos_step_runner/step_runner.py
@@ -1,9 +1,12 @@
 """Constructs a given named StepImplementer using a given configuration, and runs it.
 """
-from ploigos_step_runner.step_implementer import StepImplementer
+import os
+
 from ploigos_step_runner.config.config import Config
 from ploigos_step_runner.exceptions import StepRunnerException
+from ploigos_step_runner.step_implementer import StepImplementer
 from ploigos_step_runner.utils.reflection import import_and_get_class
+from ploigos_step_runner.workflow_result import WorkflowResult
 
 
 class StepRunner:
@@ -47,20 +50,22 @@ class StepRunner:
     __DEFAULT_MODULE = 'ploigos_step_runner.step_implementers'
 
     def __init__(
-            self,
-            config,
-            results_dir_path='step-runner-results',
-            results_file_name='step-runner-results.yml',
-            work_dir_path='step-runner-working'):
-
+        self,
+        config,
+        results_dir_path='step-runner-results',
+        results_file_name='step-runner-results.yml',
+        work_dir_path='step-runner-working'
+    ):
         if isinstance(config, Config):
             self.__config = config
         else:
             self.__config = Config(config)
 
-        self.results_dir_path = results_dir_path
-        self.results_file_name = results_file_name
-        self.work_dir_path = work_dir_path
+        self.__results_dir_path = results_dir_path
+        self.__results_file_name = results_file_name
+        self.__work_dir_path = work_dir_path
+
+        self.__workflow_result = None
 
     @property
     def config(self):
@@ -71,6 +76,47 @@ class StepRunner:
             Configuration used by this factory.
         """
         return self.__config
+
+    @property
+    def results_file_path(self):
+        """Get the full path to the results file.
+
+        Returns
+        -------
+        str
+            Full path to the results file.
+        """
+        return os.path.join(self.__results_dir_path, self.__results_file_name)
+
+    @property
+    def workflow_result_pickle_file_path(self):
+        """
+        Get the full path to the workflow result pickle file.
+        (The 'pickle' file contains the serialized list of step results.)
+        The name of the pickle file is the basename of the results_file_name.
+
+        Returns
+        -------
+        str
+           Full path to the workflow pickle (serialized) file.
+        """
+        pickle_filename = os.path.splitext(self.__results_file_name)[0] + '.pkl'
+        return os.path.join(self.__work_dir_path, pickle_filename)
+
+    @property
+    def workflow_result(self):
+        """
+        Returns
+        -------
+        WorkflowResult
+            Object containing a list of dictionary of step results
+            from previous steps.
+        """
+        if not self.__workflow_result:
+            self.__workflow_result = WorkflowResult.load_from_pickle_file(
+                pickle_filename=self.workflow_result_pickle_file_path
+            )
+        return self.__workflow_result
 
     def run_step(self, step_name, environment=None):
         """
@@ -113,15 +159,25 @@ class StepRunner:
 
             # create the StepImplementer instance
             sub_step = step_implementer_class(
-                results_dir_path=self.results_dir_path,
-                results_file_name=self.results_file_name,
-                work_dir_path=self.work_dir_path,
+                work_dir_path=self.__work_dir_path,
                 config=sub_step_config,
-                environment=environment
+                environment=environment,
+                workflow_result=self.workflow_result
             )
 
             # run the step
             step_result = sub_step.run_step()
+
+            # save the step results
+            self.workflow_result.add_step_result(
+                step_result=step_result
+            )
+            self.workflow_result.write_to_pickle_file(
+                pickle_filename=self.workflow_result_pickle_file_path
+            )
+            self.workflow_result.write_results_to_yml_file(
+                yml_filename=self.results_file_path
+            )
 
             # bail out if one of the sub steps fails
             if not step_result.success:

--- a/tests/helpers/base_step_implementer_test_case.py
+++ b/tests/helpers/base_step_implementer_test_case.py
@@ -23,8 +23,7 @@ class BaseStepImplementerTestCase(BaseTestCase):
         step_name='',
         environment=None,
         implementer='',
-        results_dir_path='',
-        results_file_name='',
+        workflow_result=None,
         work_dir_path='',
     ):
         config = Config({
@@ -41,9 +40,11 @@ class BaseStepImplementerTestCase(BaseTestCase):
         step_config = config.get_step_config(step_name)
         sub_step_config = step_config.get_sub_step(implementer)
 
+        if not workflow_result:
+            workflow_result = WorkflowResult()
+
         step_implementer = step_implementer(
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path,
             config=sub_step_config,
             environment=environment
@@ -80,3 +81,5 @@ class BaseStepImplementerTestCase(BaseTestCase):
         workflow_result.add_step_result(step_result=step_result)
         pickle_filename = os.path.join(work_dir_path, 'step-runner-results.pkl')
         workflow_result.write_to_pickle_file(pickle_filename=pickle_filename)
+
+        return workflow_result

--- a/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
+++ b/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
@@ -14,8 +14,7 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
             step_config={},
             step_name='test',
             implementer='OpenSCAP',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -23,8 +22,7 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -36,16 +34,12 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -60,16 +54,12 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -91,16 +81,12 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -122,16 +108,12 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -147,16 +129,12 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
     def test__validate_required_config_or_previous_step_result_artifact_keys_missing_required_keys(self):
         step_config = {}
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 

--- a/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
+++ b/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
@@ -10,8 +10,7 @@ class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepI
             step_config={},
             step_name='test',
             implementer='OpenSCAP',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -19,7 +18,6 @@ class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepI
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -18,8 +18,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -27,8 +26,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -60,10 +58,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
@@ -74,21 +75,15 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
 
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -133,8 +128,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass_no_container_image_version(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
@@ -152,8 +145,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -199,10 +190,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass_image_tar_file_exists(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
@@ -213,23 +207,15 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             step_implementer.write_working_file('image-app-name-service-name-1.0-123abc.tar')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -274,29 +260,24 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_no_image_spec_file(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -313,10 +294,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_buildah_bud_error(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             image_spec_file = 'Dockerfile'
             step_config = {
@@ -328,21 +312,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             buildah_mock.bud.side_effect = sh.ErrorReturnCode('buildah', b'mock out', b'mock error')
 
@@ -366,14 +342,18 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_buildah_push_error(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             application_name = 'app-name'
             service_name = 'service-name'
             image_tag_version = '1.0-123abc'
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': image_tag_version},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Dockerfile',
@@ -383,20 +363,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 'service-name': service_name,
                 'application-name': application_name
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': image_tag_version},
-            }
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             buildah_mock.push.side_effect = sh.ErrorReturnCode('buildah', b'mock out', b'mock error')
 

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -17,8 +17,6 @@ class TestStepImplementerDeployArgoCDBase(BaseStepImplementerTestCase):
     def create_step_implementer(
         self,
         step_config={},
-        results_dir_path='',
-        results_file_name='',
         work_dir_path='',
         environment=None
     ):
@@ -27,11 +25,10 @@ class TestStepImplementerDeployArgoCDBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name='deploy',
             implementer='ArgoCD',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
             work_dir_path=work_dir_path,
             environment=environment
         )
+
 class TestStepImplementerDeployArgoCD_Other(TestStepImplementerDeployArgoCDBase):
     def test_step_implementer_config_defaults(self):
         defaults = ArgoCD.step_implementer_config_defaults()
@@ -70,8 +67,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 ):
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_success_ssh(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -87,8 +82,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -96,8 +89,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_success_https(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -115,8 +106,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -124,8 +113,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_username(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -142,8 +129,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -155,8 +140,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_password(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -173,8 +156,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -186,8 +167,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_creds(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -203,8 +182,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -218,8 +195,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_http_no_git_creds(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -235,8 +210,6 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -296,8 +269,6 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
         argocd_get_app_manifest_mock
     ):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -313,8 +284,6 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
                 environment='PROD'
             )
@@ -455,8 +424,6 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
         argocd_get_app_manifest_mock
     ):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
@@ -472,8 +439,6 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
                 environment='PROD'
             )
@@ -532,16 +497,12 @@ class TestStepImplementerDeployArgoCD__get_container_image_version(
 ):
     def test_ArgoCD__get_container_image_version_config_value(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'container-image-version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -550,15 +511,11 @@ class TestStepImplementerDeployArgoCD__get_container_image_version(
 
     def test_ArgoCD__get_container_image_version_no_config_value(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -570,16 +527,12 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 ):
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_config_value(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'deployment-config-helm-chart-environment-values-file': 'values-AWEOMSE.yaml'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -592,15 +545,11 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_no_config_value_no_env(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -613,15 +562,11 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_no_config_value_with_env(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
                 environment='PROD'
             )
@@ -637,15 +582,11 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
     @patch('sh.yq', create=True)
     def test_ArgoCD__update_yaml_file_value_success(self, yq_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -679,15 +620,11 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
     @patch('sh.yq', create=True)
     def test_ArgoCD__update_yaml_file_value_fail(self, yq_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -741,8 +678,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_http(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
@@ -750,8 +685,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -771,8 +704,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_https(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
@@ -780,8 +711,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -801,8 +730,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_ssh(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
@@ -810,8 +737,6 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -832,8 +757,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_no_env_less_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
@@ -842,8 +765,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -853,8 +774,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/TEST')
     def test_ArgoCD__get_app_name_no_env_less_then_max_length_caps(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
@@ -863,8 +782,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -874,8 +791,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_no_env_more_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
@@ -884,8 +799,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -895,8 +808,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_with_env_less_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
@@ -905,8 +816,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
                 environment='PROD'
             )
@@ -917,8 +826,6 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
 class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepImplementerDeployArgoCDBase):
     def test_ArgoCD__get_deployment_config_repo_tag_use_tag(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'tag': 'v0.42.0-abc123',
@@ -926,8 +833,6 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -936,16 +841,12 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_version(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -955,15 +856,11 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_latest(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -972,8 +869,6 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_tag_with_env(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'tag': 'v0.42.0-main+abc123',
@@ -981,8 +876,6 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
                 environment='PROD'
             )
@@ -2243,13 +2136,9 @@ class TestStepImplementerDeployArgoCD__argocd_add_target_cluster(TestStepImpleme
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_default_cluster(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -2263,13 +2152,9 @@ class TestStepImplementerDeployArgoCD__argocd_add_target_cluster(TestStepImpleme
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_custom_cluster_kube_skip_tls_true(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
@@ -2325,13 +2210,9 @@ users:
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_custom_cluster_kube_skip_tls_false(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
@@ -2387,13 +2268,9 @@ users:
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_fail_custom_cluster_kube_skip_tls_true(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
@@ -2753,13 +2630,9 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_success_live(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -2779,13 +2652,9 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_success_git(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -2805,14 +2674,10 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_fail(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config={},
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -18,8 +18,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -27,8 +26,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -47,8 +45,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
@@ -62,8 +58,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -74,8 +68,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_root_dir_is_not_git_repo(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'repo-root': '/'
@@ -85,8 +77,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -104,8 +94,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_root_dir_is_bare_git_repo(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             Repo.init(str(temp_dir.path), bare=True)
 
@@ -117,8 +105,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -136,8 +122,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_no_commit_history(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             Repo.init(str(temp_dir.path))
 
@@ -149,8 +133,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -173,8 +155,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_git_repo_with_single_commit_on_master(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
@@ -188,8 +168,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -200,8 +178,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_git_repo_with_single_commit_on_feature(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
@@ -219,8 +195,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -232,8 +206,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_directory_is_detached(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
@@ -252,8 +224,6 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
@@ -16,8 +16,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -25,8 +24,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -44,8 +42,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
@@ -63,8 +59,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -72,8 +66,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_package_file_does_not_exist(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
@@ -85,8 +77,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -98,8 +88,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
@@ -117,8 +105,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -135,8 +121,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_version_in_pom_file(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
@@ -153,8 +137,6 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/generate_metadata/test_npm_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_npm_generate_metadata.py
@@ -13,8 +13,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -22,8 +21,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -43,8 +41,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('package.json', b'''{
@@ -61,8 +57,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='test',
                 implementer='Npm',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -70,8 +64,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_package_file_does_not_exist(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             package_file_path = os.path.join(temp_dir.path, 'package.json')
             step_config = {
@@ -82,8 +74,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='test',
                 implementer='Npm',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -95,8 +85,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('package.json', b'''{
               "name": "my-awesome-package",
@@ -110,8 +98,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Npm',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -129,8 +115,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_version_in_package_file(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('package.json', b'''{
               "name": "my-awesome-package"
@@ -143,8 +127,6 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Npm',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -17,8 +17,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -26,8 +25,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -50,8 +48,6 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
@@ -61,16 +57,14 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
                 'pre-release': {'description': '', 'value': 'master'},
                 'build': {'description': '', 'value': 'abc123'}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='SemanticVersion',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -87,8 +81,6 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
 
     def test_run_step_pass_different_pre_release(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
@@ -98,16 +90,14 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
                 'pre-release': {'description': '', 'value': 'feature123'},
                 'build': {'description': '', 'value': 'abc123'}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='SemanticVersion',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -20,8 +20,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -29,8 +28,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -87,8 +85,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'war'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -107,8 +103,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -151,8 +145,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'jar'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -170,8 +162,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -208,8 +198,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail_no_pom(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
@@ -218,8 +206,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -234,8 +220,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail_mvn_error(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -251,8 +235,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -296,8 +278,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'jar'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -315,8 +295,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -352,8 +330,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = ''
             version = ''
             package = ''
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -371,8 +347,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -406,8 +380,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'war'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -429,8 +401,6 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -19,8 +19,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -28,8 +27,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -53,8 +51,6 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_pass(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
@@ -73,16 +69,15 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='push-artifacts',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
             result = step_implementer._run_step()
 
@@ -115,8 +110,6 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             # config
@@ -136,16 +129,15 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='push-artifacts',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
             sh.mvn.side_effect = sh.ErrorReturnCode('mvn', b'mock out', b'mock error')
 
@@ -187,8 +179,6 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_tls_verify_false(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
@@ -208,16 +198,15 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='push-artifacts',
                 implementer='Maven',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
             result = step_implementer._run_step()
 

--- a/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
+++ b/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
@@ -22,8 +22,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -31,8 +30,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -63,8 +61,6 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
     @patch.object(sh, 'skopeo', create=True)
     def test_run_step_pass(self, skopeo_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             image_tar_file = 'fake-image.tar'
@@ -82,8 +78,6 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='push-container-image',
                 implementer='Skopeo',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -138,8 +132,6 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
     @patch.object(sh, 'skopeo', create=True)
     def test_run_step_fail_run_skopeo(self, skopeo_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             image_tar_file = 'fake-image.tar'
@@ -157,8 +149,6 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='push-container-image',
                 implementer='Skopeo',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/shared/test_maven_generic.py
+++ b/tests/step_implementers/shared/test_maven_generic.py
@@ -28,8 +28,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -37,8 +36,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name='foo',
             implementer='SampleMavenStepImplementer',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -76,8 +74,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -116,8 +112,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -138,8 +132,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -163,8 +155,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -198,8 +188,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -241,8 +229,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/shared/test_openscap_generic.py
+++ b/tests/step_implementers/shared/test_openscap_generic.py
@@ -23,8 +23,7 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -32,8 +31,7 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -59,16 +57,12 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -81,16 +75,12 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             'image-tar-file': 'does-not-matter'
         }
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -112,16 +102,12 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -137,16 +123,12 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
     def test__validate_required_config_or_previous_step_result_artifact_keys_missing_required_keys(self):
         step_config = {}
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -1007,24 +989,20 @@ Result	pass
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1099,24 +1077,20 @@ Result	fail
 """
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1189,24 +1163,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1282,24 +1252,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1370,24 +1336,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type

--- a/tests/step_implementers/sign_container_image/test_curl_push.py
+++ b/tests/step_implementers/sign_container_image/test_curl_push.py
@@ -21,8 +21,7 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -30,8 +29,7 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -55,8 +53,6 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
     @patch('sh.curl', create=True)
     def test_run_step_pass(self, curl_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             signature_file_path = 'signature-1'
             temp_dir.write(signature_file_path, b'bogus signature')
@@ -77,16 +73,15 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
                 'container-image-signature-file-path': {'value': container_image_signature_file_path},
                 'container-image-signature-name': {'value': container_image_signature_name},
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='CurlPush',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -111,8 +106,6 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
     @patch('sh.curl', create=True)
     def test_run_step_pass_nofips(self, curl_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             signature_file_path = 'signature-1'
             temp_dir.write(signature_file_path, b'bogus signature')
@@ -133,16 +126,15 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
                 'container-image-signature-file-path': {'value': container_image_signature_file_path},
                 'container-image-signature-name': {'value': container_image_signature_name},
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='CurlPush',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -171,8 +163,6 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
     @patch('sh.curl', create=True)
     def test_run_step_fail(self, curl_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             signature_file_path = 'signature-1'
             temp_dir.write(signature_file_path, b'bogus signature')
@@ -192,16 +182,15 @@ class TestStepImplementerCurlPushSourceBase(BaseStepImplementerTestCase):
                 'container-image-signature-file-path': {'value': container_image_signature_file_path},
                 'container-image-signature-name': {'value': container_image_signature_name},
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='CurlPush',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
             sh.curl.side_effect = sh.ErrorReturnCode('curl', b'mock stdout', b'mock error')
 

--- a/tests/step_implementers/sign_container_image/test_podman_sign.py
+++ b/tests/step_implementers/sign_container_image/test_podman_sign.py
@@ -77,8 +77,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -86,8 +85,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -108,8 +106,6 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_pass(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
@@ -120,7 +116,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -139,9 +135,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='PodmanSign',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -184,8 +179,6 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_fail_import_pgp_key(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             container_image_tag = 'does/not/matter:v0.42.0'
@@ -195,7 +188,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             import_pgp_key_mock.side_effect = StepRunnerException('mock error importing pgp key')
 
@@ -213,9 +206,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='PodmanSign',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -237,8 +229,6 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_fail_sign_image(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
@@ -248,7 +238,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -261,9 +251,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='sign-container-image',
                 implementer='PodmanSign',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
+++ b/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
@@ -20,8 +20,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -29,8 +28,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -64,16 +62,12 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -88,16 +82,12 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             'version': 'notused'
         }
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
             with self.assertRaisesRegex(
@@ -115,16 +105,12 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             'version': 'notused'
         }
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
             with self.assertRaisesRegex(
@@ -136,11 +122,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
+
+            artifact_config = {
+                'version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -151,21 +140,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 'password': 'password'
 
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -197,11 +178,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass_no_username_and_password(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
+
+            artifact_config = {
+                'version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -210,21 +194,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 'service-name': 'service-name'
 
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -254,9 +230,12 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_fail_no_properties(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': 'https://sonarqube-sonarqube.apps.ploigos_step_runner.rht-set.com',
@@ -264,21 +243,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 'service-name': 'service-name'
 
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
-
-            artifact_config = {
-                'version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -295,13 +266,16 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass_alternate_java_truststore(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties', b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
             temp_dir.write('alternate.jks', b'''testing''')
             java_truststore = os.path.join(temp_dir.path, 'alternate.jks')
+
+            artifact_config = {
+                'version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -312,21 +286,15 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 'password': 'password',
                 'java-truststore': java_truststore
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
-            artifact_config = {
-                'version': {'description': '', 'value': '1.0-123abc'},
-            }
 
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             result = step_implementer._run_step()
 
@@ -362,11 +330,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
         sonar_mock
     ):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
+
+            artifact_config = {
+                'version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -377,21 +348,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 'password': 'password'
 
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
+                workflow_result=workflow_result,
                 work_dir_path=work_dir_path,
             )
-
-            artifact_config = {
-                'version': {'description': '', 'value': '1.0-123abc'},
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
 
             sonar_mock.side_effect = sonar_scanner_error
 

--- a/tests/step_implementers/tag_source/test_git_tag_source.py
+++ b/tests/step_implementers/tag_source/test_git_tag_source.py
@@ -18,19 +18,17 @@ from ploigos_step_runner.step_result import StepResult
 
 class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
     def create_step_implementer(
-            self,
-            step_config={},
-            results_dir_path='',
-            results_file_name='',
-            work_dir_path=''
+        self,
+        workflow_result=None,
+        step_config={},
+        work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Git,
             step_config=step_config,
             step_name='tag-source',
             implementer='Git',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -47,8 +45,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
          with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
@@ -57,8 +53,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -66,8 +60,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_username(self):
          with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
@@ -75,8 +67,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -88,8 +78,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_password(self):
          with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
@@ -97,8 +85,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -119,8 +105,6 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
@@ -134,12 +118,11 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 'container-image-version': {'description': '', 'value': tag}
             }
 
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
+                workflow_result=workflow_result,
                 work_dir_path=work_dir_path,
             )
 
@@ -173,27 +156,22 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
                 'git-password': 'git-password'
             }
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': tag}
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -226,28 +204,23 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
                 'git-password': 'git-password'
             }
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -280,26 +253,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {
-                'url': url
-            }
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {
+                'url': url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -332,26 +300,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {
-                'url': url
-            }
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {
+                'url': url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -384,26 +347,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {
-                'url': url
-            }
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {
+                'url': url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -435,28 +393,23 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
                 'git-password': 'git-password'
             }
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -494,28 +447,23 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
                 'git-password': 'git-password'
             }
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -550,28 +498,23 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
                 'git-password': 'git-password'
             }
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-
-            self.setup_previous_result(work_dir_path, artifact_config)
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def get_tag_side_effect():
@@ -613,25 +556,20 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = 'latest'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {
-                'url': url
-            }
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': tag}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {
+                'url': url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             def git_url_side_effect():
@@ -665,23 +603,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         remote_origin_url = "https://does.not.matter.xyz/foo.git"
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             git_mock.config.side_effect = TestStepImplementerTagSourceGit.\
@@ -694,23 +627,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
     @patch('sh.git', create=True)
     def test__git_url_url_from_git_config_error(self, git_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             git_mock.config.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
@@ -726,25 +654,20 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         remote_origin_url = "https://does.not.matter.xyz/foo.git"
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {
-                'url': remote_origin_url
-            }
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {
+                'url': remote_origin_url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             git_mock.assert_not_called()
@@ -760,23 +683,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         git_tag_value = "1.0+69442c8"
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             step_implementer._Git__git_tag(git_tag_value)
@@ -794,23 +712,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         git_tag_value = "1.0+69442c8"
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             git_mock.tag.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
@@ -828,23 +741,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         url = 'www.xyz.com'
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             step_implementer._Git__git_push(url)
@@ -861,23 +769,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
     def test__git_push_no_url_success(self, git_mock):
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             step_implementer._Git__git_push(None)
@@ -894,23 +797,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         url = 'www.xyz.com'
 
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_config = {}
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            self.setup_previous_result(work_dir_path, artifact_config)
-
+            step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             git_mock.push.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')

--- a/tests/step_implementers/uat/test_maven_selenium_cucumber.py
+++ b/tests/step_implementers/uat/test_maven_selenium_cucumber.py
@@ -19,8 +19,6 @@ class TestStepImplementerMavenSeleniumCucumberBase(MaveStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
-            results_dir_path='',
-            results_file_name='',
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -28,8 +26,6 @@ class TestStepImplementerMavenSeleniumCucumberBase(MaveStepImplementerTestCase):
             step_config=step_config,
             step_name='uat',
             implementer='MavenSeleniumCucumber',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
             work_dir_path=work_dir_path
         )
 
@@ -38,8 +34,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
 ):
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_target_host_url(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
@@ -51,8 +45,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -60,8 +52,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_deployed_host_urls_1(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
@@ -73,8 +63,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -82,8 +70,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_deployed_host_urls_2(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
@@ -95,8 +81,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -104,8 +88,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_fail_no_target_urls(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
@@ -116,8 +98,6 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -173,8 +153,6 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
         raise_error_on_tests=False,
         set_tls_verify_false=False
     ):
-        results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-        results_file_name = 'step-runner-results.yml'
         work_dir_path = os.path.join(test_dir.path, 'working')
 
         cucumber_html_report_path = os.path.join(work_dir_path, 'cucumber.html')
@@ -211,8 +189,6 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
             uat_maven_profile = 'integration-test'
         step_implementer = self.create_step_implementer(
             step_config=step_config,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
             work_dir_path=work_dir_path,
         )
 

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -19,8 +19,6 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
-            results_dir_path='',
-            results_file_name='',
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -28,8 +26,6 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
             step_config=step_config,
             step_name='unit-test',
             implementer='Maven',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
             work_dir_path=work_dir_path
         )
 
@@ -70,8 +66,6 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
         raise_error_on_tests=False,
         set_tls_verify_false=False,
     ):
-        results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-        results_file_name = 'step-runner-results.yml'
         work_dir_path = os.path.join(test_dir.path, 'working')
 
         test_dir.write('pom.xml', pom_content)
@@ -89,8 +83,6 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
             step_config['fail-on-no-tests'] = fail_on_no_tests
         step_implementer = self.create_step_implementer(
             step_config=step_config,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
             work_dir_path=work_dir_path,
         )
 

--- a/tests/step_implementers/validate_environment_configuration/test_configlint.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint.py
@@ -38,8 +38,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -47,8 +46,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -70,8 +68,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_bad_yml_path(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -85,8 +81,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -105,8 +99,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_bad_rule_path(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -120,8 +112,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -140,8 +130,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_pass_prev_step(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -153,15 +141,14 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             artifact_config = {
                 'configlint-yml-path': {'value': f'{test_file_path}'}
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -185,8 +172,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_scan(self, configlint_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             file_to_validate_contents = 'notused'
             temp_dir.write('config-file-to-validate.yml', file_to_validate_contents.encode())
@@ -212,8 +197,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 
@@ -240,8 +223,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_pass(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'file.txt'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -255,8 +236,6 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path,
             )
 

--- a/tests/step_implementers/validate_environment_configuration/test_configlint_from_argocd.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint_from_argocd.py
@@ -17,8 +17,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
             step_config={},
             step_name='',
             implementer='',
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path=''
     ):
         return self.create_given_step_implementer(
@@ -26,8 +25,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name=step_name,
             implementer=implementer,
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path
         )
 
@@ -47,8 +45,6 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'yamlnotused'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -60,15 +56,14 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
                     'value': test_file_path
                 }
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='ConfiglintArgocd',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -87,8 +82,6 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_path_file_from_deploy(self):
         with TempDirectory() as temp_dir:
-            results_dir_path = os.path.join(temp_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'yamlnotused'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
@@ -100,15 +93,14 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
                     'value': f'{test_file_path}.bad'
                 }
             }
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='ConfiglintArgocd',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
-                work_dir_path=work_dir_path,
+                workflow_result=workflow_result,
+                work_dir_path=work_dir_path
             )
 
             result = step_implementer._run_step()

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -755,7 +755,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             )
             result = step.run_step()
 
-        self.assertEqual(False, result)
+        self.assertEqual(False, result.success)
 
     def test_create_working_dir_sub_dir(self):
         config = Config({

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -34,9 +34,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
         )
 
         pickle = f'{working_dir_path}/step-runner-results.pkl'
-        workflow_results = WorkflowResult.load_from_pickle_file(pickle)
+        workflow_result = WorkflowResult.load_from_pickle_file(pickle)
 
-        step_result = workflow_results.get_step_result(
+        step_result = workflow_result.get_step_result(
             step_name=step
         )
         self.assertEqual(expected_step_results, step_result.get_step_result_dict())
@@ -516,8 +516,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'WriteConfigAsResultsStepImplementer')
 
         step = WriteConfigAsResultsStepImplementer(
-            results_dir_path='',
-            results_file_name='',
+            workflow_result=None,
             work_dir_path='',
             config=sub_step
         )
@@ -575,11 +574,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FooStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step
             )
@@ -604,11 +601,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FooStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step
             )
@@ -627,8 +622,6 @@ class TestStepImplementer(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             step = self.create_given_step_implementer(
@@ -636,8 +629,6 @@ class TestStepImplementer(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='foo',
                 implementer='FooStepImplementer',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
                 work_dir_path=work_dir_path
             )
 
@@ -669,11 +660,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FooStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step,
                 environment='SAMPLE-ENV-1'
@@ -712,11 +701,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FooStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step,
                 environment='SAMPLE-ENV-1'
@@ -745,11 +732,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FailStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FailStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step
             )
@@ -771,11 +756,9 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'tests.helpers.sample_step_implementers.FooStepImplementer')
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='step-runner-results.yml',
+                workflow_result=WorkflowResult(),
                 work_dir_path=working_dir_path,
                 config=sub_step
             )
@@ -788,63 +771,12 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             self.assertEqual(sub, f'{working_dir_path}/foo/folder1/folder2/folder3')
             self.assertEqual(True, os.path.isdir(sub))
 
-    def test_result_files_and_paths(self):
-        # overkill on tests here
-        config = Config({
-            'step-runner-config': {
-                'foo': {
-                    'implementer': 'tests.helpers.sample_step_implementers.FooStepImplementer',
-                    'config': {}
-                }
-            }
-        })
-        step_config = config.get_step_config('foo')
-        sub_step = step_config.get_sub_step(
-            'tests.helpers.sample_step_implementers.FooStepImplementer')
-
-        with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'myresults')
-            working_dir_path = os.path.join(test_dir.path, 'mytesting')
-            step = FooStepImplementer(
-                results_dir_path=results_dir_path,
-                results_file_name='myfile',
-                work_dir_path=working_dir_path,
-                config=sub_step
-            )
-
-            self.assertEqual(
-                f'{results_dir_path}/myfile',
-                step.results_file_path
-            )
-
-            self.assertEqual(
-                f'{results_dir_path}',
-                step.results_dir_path
-            )
-
-            self.assertEqual(
-                f'{working_dir_path}',
-                step.work_dir_path
-            )
-
-            self.assertEqual(
-                f'{working_dir_path}/foo',
-                step.work_dir_path_step
-            )
-
-            self.assertEqual(
-                f'{working_dir_path}/myfile.pkl',
-                step._StepImplementer__workflow_result_pickle_file_path
-            )
-
     def test_get_value_no_env(self):
         step_config = {
             'test': 'hello world'
         }
 
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             artifact_config = {
@@ -854,15 +786,14 @@ class TestStepImplementer(BaseStepImplementerTestCase):
                 },
             }
 
-            self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
             step = self.create_given_step_implementer(
                 step_implementer=FooStepImplementer,
                 step_config=step_config,
                 step_name='foo',
                 implementer='FooStepImplementer',
-                results_dir_path=results_dir_path,
-                results_file_name=results_file_name,
+                workflow_result=workflow_result,
                 work_dir_path=work_dir_path
             )
 
@@ -875,8 +806,6 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'test': 'hello world'
         }
 
-        results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-        results_file_name = 'step-runner-results.yml'
         work_dir_path = os.path.join(test_dir.path, 'working')
 
         workflow_result = WorkflowResult()
@@ -912,8 +841,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name='foo',
             implementer='FooStepImplementer',
-            results_dir_path=results_dir_path,
-            results_file_name=results_file_name,
+            workflow_result=workflow_result,
             work_dir_path=work_dir_path,
             environment=environment
         )


### PR DESCRIPTION
# purpose

currently the saving of the WorkflowResult happens in StepImpeneter. Moving that to StepRunner simplifies things and sets bases for future work with collecting the workflow results, generating reports, and doing attistations. This is basically a misstep refactor but rather then one giant MR that does the refactor and the work we actually want to do, putting this in on its own.