### PR TITLE
Fixes issue where config.yml values were returned as ConfigValue objects when calling get_value(). 

### DIFF
--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -451,8 +451,9 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
         # first try to get config value
         config_value = self.get_config_value(key)
+        # config_value might be a list of ConfigValue objects that need to be converted
         if config_value is not None:
-            return config_value
+            return ConfigValue.convert_leaves_to_values(config_value)
 
         # if not found config value try to get result value specific to current environment
         if self.environment:


### PR DESCRIPTION
Specifying the 'artifact-extensions' variable in config.yml would result in an error during the package stage: 
"TypeError: endswith first arg must be str or a tuple of str, not ConfigValue".
 