### PR TITLE
PGP & Rekor refactor

### DIFF
--- a/src/ploigos_step_runner/__init__.py
+++ b/src/ploigos_step_runner/__init__.py
@@ -374,9 +374,9 @@ From least precedence to highest precedence.
       automated-governance:
       - implementer: Rekor
         config: {
-          rekor-server: 'http://example-rekor-server-url/',
-          gpg-key: '/path/to/gpg-key',
-          gpg-user: 'gpg-user@example.com'
+          rekor-server-url: 'http://example-rekor-server-url-url/',
+          signer-pgp-public-key-path: '/path/to/signer-pgp-public-key-path',
+          signer-pgp-private-key-user: 'signer-pgp-private-key-user@example.com'
         }
 
       push-container-image:
@@ -687,9 +687,9 @@ From least precedence to highest precedence.
       automated-governance:
       - implementer: Rekor
         config: {
-          rekor-server: 'http://example-rekor-server-url/',
-          gpg-key: '/path/to/gpg-key',
-          gpg-user: 'gpg-user@example.com'
+          rekor-server-url: 'http://example-rekor-server-url-url/',
+          signer-pgp-public-key-path: '/path/to/signer-pgp-public-key-path',
+          signer-pgp-private-key-user: 'signer-pgp-private-key-user@example.com'
         }
 
       push-container-image:

--- a/tests/helpers/base_step_implementer_test_case.py
+++ b/tests/helpers/base_step_implementer_test_case.py
@@ -1,15 +1,8 @@
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
-# pylint: disable=missing-function-docstring
 import os
-from contextlib import redirect_stderr, redirect_stdout
-from io import StringIO
 
-import yaml
 from ploigos_step_runner import StepResult, WorkflowResult
 from ploigos_step_runner.config.config import Config
 from ploigos_step_runner.exceptions import StepRunnerException
-from ploigos_step_runner.step_runner import StepRunner
 
 from .base_test_case import BaseTestCase
 

--- a/tests/helpers/sample_step_implementers.py
+++ b/tests/helpers/sample_step_implementers.py
@@ -51,7 +51,25 @@ class RequiredStepConfigStepImplementer(StepImplementer):
             step_result.add_artifact(name=n, value=v)
         return step_result
 
+class RequiredStepConfigMultipleOptionsStepImplementer(StepImplementer):
+    @staticmethod
+    def step_implementer_config_defaults():
+        return {}
 
+    @staticmethod
+    def _required_config_or_result_keys():
+        return [
+            ['new-required-key', 'old-required-key']
+        ]
+
+    def _run_step(self):
+        step_result = StepResult.from_step_implementer(self)
+        runtime_step_config = self.config.get_copy_of_runtime_step_config(
+            self.environment,
+            self.step_implementer_config_defaults())
+        for n, v in ConfigValue.convert_leaves_to_values(runtime_step_config).items():
+            step_result.add_artifact(name=n, value=v)
+        return step_result
 class WriteConfigAsResultsStepImplementer(StepImplementer):
     @staticmethod
     def step_implementer_config_defaults():

--- a/tests/step_implementers/sign_container_image/test_podman_sign.py
+++ b/tests/step_implementers/sign_container_image/test_podman_sign.py
@@ -38,7 +38,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @staticmethod
     def generate_config():
         return {
-            'container-image-signer-pgp-private-key': \
+            'signer-pgp-private-key': \
                 TestStepImplementerSignContainerImagePodman.TEST_FAKE_PRIVATE_KEY
         }
 
@@ -94,7 +94,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     def test__required_config_or_result_keys(self):
         required_keys = PodmanSign._required_config_or_result_keys()
         expected_required_keys = [
-            'container-image-signer-pgp-private-key',
+            ['signer-pgp-private-key', 'container-image-signer-pgp-private-key'],
             'container-image-tag'
         ]
         self.assertEqual(required_keys, expected_required_keys)
@@ -138,7 +138,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
@@ -167,7 +167,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 value=signature_name
             )
             expected_step_result.add_artifact(
-                name='container-image-signature-private-key-fingerprint',
+                name='container-image-signature-signer-private-key-fingerprint',
                 value=pgp_private_key_fingerprint
             )
             self.assertEqual(expected_step_result, result)
@@ -220,7 +220,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
@@ -255,7 +255,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 value=signature_name
             )
             expected_step_result.add_artifact(
-                name='container-image-signature-private-key-fingerprint',
+                name='container-image-signature-signer-private-key-fingerprint',
                 value=pgp_private_key_fingerprint
             )
             expected_step_result.add_artifact(
@@ -323,7 +323,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
@@ -358,7 +358,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 value=signature_name
             )
             expected_step_result.add_artifact(
-                name='container-image-signature-private-key-fingerprint',
+                name='container-image-signature-signer-private-key-fingerprint',
                 value=pgp_private_key_fingerprint
             )
             expected_step_result.add_artifact(
@@ -427,7 +427,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             result = step_implementer._run_step()
 
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
@@ -462,7 +462,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 value=signature_name
             )
             expected_step_result.add_artifact(
-                name='container-image-signature-private-key-fingerprint',
+                name='container-image-signature-signer-private-key-fingerprint',
                 value=pgp_private_key_fingerprint
             )
             expected_step_result.add_artifact(
@@ -473,6 +473,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = 'mock upload error'
 
+            print(expected_step_result)
+            print(result)
             self.assertEqual(expected_step_result, result)
     @patch('ploigos_step_runner.step_implementers.sign_container_image.podman_sign.import_pgp_key')
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
@@ -489,7 +491,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             }
             workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
 
-            import_pgp_key_mock.side_effect = StepRunnerException('mock error importing pgp key')
+            import_pgp_key_mock.side_effect = RuntimeError('mock error importing pgp key')
 
             def sign_image_side_effect(
                     pgp_private_key_fingerprint,
@@ -511,7 +513,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
 
             expected_step_result = StepResult(
@@ -522,6 +524,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = 'mock error importing pgp key'
 
+            print(expected_step_result)
+            print(result)
             self.assertEqual(expected_step_result, result)
 
     @patch('ploigos_step_runner.step_implementers.sign_container_image.podman_sign.import_pgp_key')
@@ -556,7 +560,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
 
             result = step_implementer._run_step()
             import_pgp_key_mock.assert_called_once_with(
-                pgp_private_key=step_config['container-image-signer-pgp-private-key']
+                pgp_private_key=step_config['signer-pgp-private-key']
             )
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
@@ -573,7 +577,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 sub_step_implementer_name='PodmanSign'
             )
             expected_step_result.add_artifact(
-                name='container-image-signature-private-key-fingerprint',
+                name='container-image-signature-signer-private-key-fingerprint',
                 value=pgp_private_key_fingerprint
             )
             expected_step_result.success = False


### PR DESCRIPTION
# purpose

* standerdize on `pgp` rather then `gpg` since PGP is the standard and `gpg` is an implementation of that standard.
* start to clean up rekor step implementer, but more work there needed. some TODOs left in there to that affect.
