### PR TITLE
Fix issues with StepImplementer instances overwriting the shared working dir

### DIFF
--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -45,7 +45,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
     ----------
     workflow_result : str
         TODO doc me
-    work_dir_path : str
+    parent_work_dir_path : str
         Path to the directory to write step working files to
     step_environment_config : dict, optional
         Step configuration specific to the current environment.
@@ -155,20 +155,6 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         return defaults_for_env
 
     @property
-    def work_dir_path(self):
-        """
-        Get the OS path to the working folder.
-        EG:  /tmp/tmpno_qi7np/step-runner-working
-
-        Returns
-        -------
-        str
-            OS path to the working folder.
-        """
-        os.makedirs(self.__work_dir_path, exist_ok=True)
-        return os.path.abspath(self.__work_dir_path)
-
-    @property
     def work_dir_path_step(self):
         """
         Get the OS path to the working folder for this step.
@@ -180,7 +166,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         str
             OS path to the working folder plus step name.
         """
-        work_dir_path_step = os.path.join(self.work_dir_path, self.step_name)
+        work_dir_path_step = os.path.join(self.__work_dir_path, self.step_name)
         if self.environment:
             work_dir_path_step = os.path.join(work_dir_path_step, self.environment)
         os.makedirs(work_dir_path_step, exist_ok=True)

--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -43,8 +43,8 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
     Parameters
     ----------
-    workflow_result : str
-        TODO doc me
+    workflow_result : WorkflowResult
+        The WorkflowResult to add StepResult to when running this StepImplementer.
     parent_work_dir_path : str
         Path to the directory to write step working files to
     step_environment_config : dict, optional
@@ -155,11 +155,9 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         return defaults_for_env
 
     @property
-    def work_dir_path_step(self):
-        """
-        Get the OS path to the working folder for this step.
+    def work_dir_path(self):
+        """Get the OS path to the working folder for this step.
         If the folder does not exist, create it.
-        EG:  /tmp/tmpno_qi7np/step-runner-working/stepname
 
         Returns
         -------
@@ -556,7 +554,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         str
             Path to created working sub directory.
         """
-        file_path = os.path.join(self.work_dir_path_step, sub_dir_relative_path)
+        file_path = os.path.join(self.work_dir_path, sub_dir_relative_path)
         os.makedirs(file_path, exist_ok=True)
         return file_path
 
@@ -576,7 +574,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             Return a string to the file path
         """
         # eg: step-runner-working/step_name
-        file_path = os.path.join(self.work_dir_path_step, filename)
+        file_path = os.path.join(self.work_dir_path, filename)
 
         # sub-directories might be passed filename, eg: foo/filename
         os.makedirs(os.path.dirname(file_path), exist_ok=True)

--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -65,11 +65,11 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
         workflow_result,
-        work_dir_path,
+        parent_work_dir_path,
         config,
         environment=None
     ):
-        self.__work_dir_path = work_dir_path
+        self.__parent_work_dir_path = parent_work_dir_path
 
         self.__config = config
         self.__environment = environment
@@ -166,7 +166,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         str
             OS path to the working folder plus step name.
         """
-        work_dir_path_step = os.path.join(self.__work_dir_path, self.step_name)
+        work_dir_path_step = os.path.join(self.__parent_work_dir_path, self.step_name)
         if self.environment:
             work_dir_path_step = os.path.join(work_dir_path_step, self.environment)
         os.makedirs(work_dir_path_step, exist_ok=True)

--- a/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
+++ b/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
@@ -182,10 +182,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
         step_result = StepResult.from_step_implementer(self)
         rekor_server = self.get_value('rekor-server-url')
         extra_data_file = os.path.join(self.work_dir_path, self.step_name+'.json')
-        extra_data_file_path = Path(extra_data_file)
-        if extra_data_file_path.exists():
-            extra_data_file_path.unlink()
-        self.workflow_result.write_results_to_json_file(extra_data_file_path)
+        self.workflow_result.write_results_to_json_file(extra_data_file)
         rekor_entry, rekor_uuid = self.upload_to_rekor(
             rekor_server=rekor_server,
             extra_data_file=extra_data_file,

--- a/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
+++ b/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
@@ -133,13 +133,12 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
         }
         return rekor_entry
 
-    @staticmethod
     def upload_to_rekor(
+        self,
         rekor_server,
         extra_data_file,
         signer_pgp_public_key_path,
-        signer_pgp_private_key_user,
-        work_dir_path
+        signer_pgp_private_key_user
     ):
         """TODO: function will be refactored in next release. will doc then.
         """
@@ -148,13 +147,12 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
             signer_pgp_private_key_user=signer_pgp_private_key_user,
             extra_data_file=extra_data_file
         )
-        print("Rekor Entry: " + str(rekor_entry))
-        rekor_entry_path = Path(os.path.join(work_dir_path, 'entry.json'))
 
-        if rekor_entry_path.exists():
-            rekor_entry_path.unlink()
-        rekor_entry_path_name = os.path.join(work_dir_path, 'entry.json')
-        rekor_entry_path.write_text(json.dumps(rekor_entry))
+        rekor_entry_path = self.write_working_file(
+            filename='entry.json',
+            contents=bytes(json.dumps(rekor_entry), 'utf-8')
+        )
+
         rekor_upload_stdout_result = StringIO()
         rekor_upload_stdout_callback = create_sh_redirect_to_multiple_streams_fn_callback([
             sys.stdout,
@@ -165,7 +163,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
             '--rekor_server',
             rekor_server,
             '--entry',
-            rekor_entry_path_name,
+            rekor_entry_path,
             _out=rekor_upload_stdout_callback,
             _err_to_out=True,
             _tee='out'
@@ -192,8 +190,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
             rekor_server=rekor_server,
             extra_data_file=extra_data_file,
             signer_pgp_public_key_path=self.get_value('signer-pgp-public-key-path'),
-            signer_pgp_private_key_user=self.get_value('signer-pgp-private-key-user'),
-            work_dir_path=self.work_dir_path_step
+            signer_pgp_private_key_user=self.get_value('signer-pgp-private-key-user')
         )
         step_result.add_artifact(
                 name='rekor-entry',

--- a/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
+++ b/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
@@ -183,7 +183,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
         """
         step_result = StepResult.from_step_implementer(self)
         rekor_server = self.get_value('rekor-server-url')
-        extra_data_file = os.path.join(self.work_dir_path, self.step_name+'.json')
+        extra_data_file = os.path.join(self.work_dir_path_step, self.step_name+'.json')
         extra_data_file_path = Path(extra_data_file)
         if extra_data_file_path.exists():
             extra_data_file_path.unlink()
@@ -193,7 +193,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
             extra_data_file=extra_data_file,
             signer_pgp_public_key_path=self.get_value('signer-pgp-public-key-path'),
             signer_pgp_private_key_user=self.get_value('signer-pgp-private-key-user'),
-            work_dir_path=self.work_dir_path
+            work_dir_path=self.work_dir_path_step
         )
         step_result.add_artifact(
                 name='rekor-entry',

--- a/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
+++ b/src/ploigos_step_runner/step_implementers/automated_governance/rekor.py
@@ -181,7 +181,7 @@ class Rekor(StepImplementer):  # pylint: disable=too-few-public-methods
         """
         step_result = StepResult.from_step_implementer(self)
         rekor_server = self.get_value('rekor-server-url')
-        extra_data_file = os.path.join(self.work_dir_path_step, self.step_name+'.json')
+        extra_data_file = os.path.join(self.work_dir_path, self.step_name+'.json')
         extra_data_file_path = Path(extra_data_file)
         if extra_data_file_path.exists():
             extra_data_file_path.unlink()

--- a/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
@@ -177,7 +177,7 @@ class Buildah(StepImplementer):
             return step_result
 
         image_tar_file = f'image-{application_name}-{service_name}-{image_tag_version}.tar'
-        image_tar_path = os.path.join(self.work_dir_path_step, image_tar_file)
+        image_tar_path = os.path.join(self.work_dir_path, image_tar_file)
         try:
             # Check to see if the tar docker-archive file already exists
             #   this needs to be run as buildah does not support overwritting
@@ -208,4 +208,3 @@ class Buildah(StepImplementer):
             return step_result
 
         return step_result
-        

--- a/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
@@ -53,7 +53,7 @@ class MavenGeneric(StepImplementer):
         )
 
         return generate_maven_settings(
-            working_dir=self.work_dir_path,
+            working_dir=self.work_dir_path_step,
             maven_servers=maven_servers,
             maven_repositories=maven_repositories,
             maven_mirrors=maven_mirrors
@@ -67,7 +67,7 @@ class MavenGeneric(StepImplementer):
         str
             Path to the written effective pom generated from the 'pom-file' value.
         """
-        effective_pom_path = os.path.join(self.work_dir_path, 'effective-pom.xml')
+        effective_pom_path = os.path.join(self.work_dir_path_step, 'effective-pom.xml')
 
         if not os.path.exists(effective_pom_path):
             write_effective_pom(

--- a/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
@@ -53,7 +53,7 @@ class MavenGeneric(StepImplementer):
         )
 
         return generate_maven_settings(
-            working_dir=self.work_dir_path_step,
+            working_dir=self.work_dir_path,
             maven_servers=maven_servers,
             maven_repositories=maven_repositories,
             maven_mirrors=maven_mirrors
@@ -67,7 +67,7 @@ class MavenGeneric(StepImplementer):
         str
             Path to the written effective pom generated from the 'pom-file' value.
         """
-        effective_pom_path = os.path.join(self.work_dir_path_step, 'effective-pom.xml')
+        effective_pom_path = os.path.join(self.work_dir_path, 'effective-pom.xml')
 
         if not os.path.exists(effective_pom_path):
             write_effective_pom(

--- a/src/ploigos_step_runner/step_implementers/shared/openscap_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/openscap_generic.py
@@ -266,7 +266,7 @@ class OpenSCAPGeneric(StepImplementer):
                 print(f"\nDownload input definitions: {oscap_input_definitions_uri}")
                 oscap_input_file = download_and_decompress_source_to_destination(
                     source_uri=oscap_input_definitions_uri,
-                    destination_dir=self.work_dir_path_step
+                    destination_dir=self.work_dir_path
                 )
                 print(f"Downloaded input definitions to: {oscap_input_file}")
             except (RuntimeError, ValueError) as error:
@@ -282,7 +282,7 @@ class OpenSCAPGeneric(StepImplementer):
                     print(f"\nDownload oscap tailoring file: {oscap_tailoring_file_uri}")
                     oscap_tailoring_file = download_and_decompress_source_to_destination(
                         source_uri=oscap_tailoring_file_uri,
-                        destination_dir=self.work_dir_path_step
+                        destination_dir=self.work_dir_path
                     )
                     print(f"Download oscap tailoring file to: {oscap_tailoring_file}")
             except (RuntimeError, ValueError) as error:

--- a/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
+++ b/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
@@ -211,7 +211,7 @@ class SonarQube(StepImplementer):
         try:
             # Hint:  Call sonar-scanner with sh.sonar_scanner
             #    https://amoffat.github.io/sh/sections/faq.html
-            working_directory = self.work_dir_path
+            working_directory = self.work_dir_path_step
             if username:
                 sh.sonar_scanner(  # pylint: disable=no-member
                     f'-Dproject.settings={properties_file}',

--- a/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
+++ b/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
@@ -211,7 +211,7 @@ class SonarQube(StepImplementer):
         try:
             # Hint:  Call sonar-scanner with sh.sonar_scanner
             #    https://amoffat.github.io/sh/sections/faq.html
-            working_directory = self.work_dir_path_step
+            working_directory = self.work_dir_path
             if username:
                 sh.sonar_scanner(  # pylint: disable=no-member
                     f'-Dproject.settings={properties_file}',

--- a/src/ploigos_step_runner/step_implementers/uat/maven_selenium_cucumber.py
+++ b/src/ploigos_step_runner/step_implementers/uat/maven_selenium_cucumber.py
@@ -190,8 +190,8 @@ class MavenSeleniumCucumber(MavenGeneric):
                 '-Dmaven.wagon.http.ssl.ignore.validity.dates=true',
             ]
 
-        cucumber_html_report_path = os.path.join(self.work_dir_path_step, 'cucumber.html')
-        cucumber_json_report_path = os.path.join(self.work_dir_path_step, 'cucumber.json')
+        cucumber_html_report_path = os.path.join(self.work_dir_path, 'cucumber.html')
+        cucumber_json_report_path = os.path.join(self.work_dir_path, 'cucumber.json')
         mvn_output_file_path = self.write_working_file('mvn_test_output.txt')
         try:
             with open(mvn_output_file_path, 'w') as mvn_output_file:

--- a/src/ploigos_step_runner/step_implementers/uat/maven_selenium_cucumber.py
+++ b/src/ploigos_step_runner/step_implementers/uat/maven_selenium_cucumber.py
@@ -190,8 +190,8 @@ class MavenSeleniumCucumber(MavenGeneric):
                 '-Dmaven.wagon.http.ssl.ignore.validity.dates=true',
             ]
 
-        cucumber_html_report_path = os.path.join(self.work_dir_path, 'cucumber.html')
-        cucumber_json_report_path = os.path.join(self.work_dir_path, 'cucumber.json')
+        cucumber_html_report_path = os.path.join(self.work_dir_path_step, 'cucumber.html')
+        cucumber_json_report_path = os.path.join(self.work_dir_path_step, 'cucumber.json')
         mvn_output_file_path = self.write_working_file('mvn_test_output.txt')
         try:
             with open(mvn_output_file_path, 'w') as mvn_output_file:

--- a/src/ploigos_step_runner/step_runner.py
+++ b/src/ploigos_step_runner/step_runner.py
@@ -154,7 +154,7 @@ class StepRunner:
 
             # create the StepImplementer instance
             sub_step = step_implementer_class(
-                work_dir_path=self.__work_dir_path,
+                parent_work_dir_path=self.__work_dir_path,
                 config=sub_step_config,
                 environment=environment,
                 workflow_result=self.workflow_result

--- a/tests/helpers/base_step_implementer_test_case.py
+++ b/tests/helpers/base_step_implementer_test_case.py
@@ -16,7 +16,7 @@ class BaseStepImplementerTestCase(BaseTestCase):
         environment=None,
         implementer='',
         workflow_result=None,
-        work_dir_path='',
+        parent_work_dir_path='',
     ):
         config = Config({
             Config.CONFIG_KEY: {
@@ -37,7 +37,7 @@ class BaseStepImplementerTestCase(BaseTestCase):
 
         step_implementer = step_implementer(
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path,
+            parent_work_dir_path=parent_work_dir_path,
             config=sub_step_config,
             environment=environment
         )

--- a/tests/results/test_step_result.py
+++ b/tests/results/test_step_result.py
@@ -229,7 +229,7 @@ class TestStepResultTest(BaseTestCase):
 
         step = FooStepImplementer(
             workflow_result=WorkflowResult(),
-            work_dir_path=None,
+            parent_work_dir_path=None,
             config=sub_step
         )
 
@@ -258,7 +258,7 @@ class TestStepResultTest(BaseTestCase):
 
         step = FooStepImplementer(
             workflow_result=WorkflowResult(),
-            work_dir_path=None,
+            parent_work_dir_path=None,
             config=sub_step,
             environment='blarg'
         )
@@ -527,7 +527,7 @@ class TestStepResultTest(BaseTestCase):
             name='evi-desc',
             value='world',
             description='test evidence'
-        )        
+        )
 
         expected = {
             'blarg': {

--- a/tests/step_implementers/automated_governance/test_rekor.py
+++ b/tests/step_implementers/automated_governance/test_rekor.py
@@ -202,7 +202,7 @@ class TestStepImplementerAutomatedGovernanceRekor(BaseStepImplementerTestCase):
             upload_mock.side_effect = upload_mock_side_effect
 
             extra_data_file = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'automated-governance.json'
             )
 

--- a/tests/step_implementers/automated_governance/test_rekor.py
+++ b/tests/step_implementers/automated_governance/test_rekor.py
@@ -156,10 +156,11 @@ class TestStepImplementerAutomatedGovernanceRekor(BaseStepImplementerTestCase):
                 'ploigos-step-runner-tests-public.key'
             )
 
-            step_config = {'rekor-server-url': TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_SERVER,
-                           'signer-pgp-public-key-path': signer_pgp_public_key_path,
-                           'signer-pgp-private-key-user': TestStepImplementerAutomatedGovernanceRekor.TEST_signer_pgp_private_key_user
-                           }
+            step_config = {
+                'rekor-server-url': TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_SERVER,
+                'signer-pgp-public-key-path': signer_pgp_public_key_path,
+                'signer-pgp-private-key-user': TestStepImplementerAutomatedGovernanceRekor.TEST_signer_pgp_private_key_user
+            }
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
@@ -172,17 +173,31 @@ class TestStepImplementerAutomatedGovernanceRekor(BaseStepImplementerTestCase):
                 sub_step_implementer_name='Rekor'
             )
 
-            expected_step_result.add_artifact(name='rekor-entry', value=TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_ENTRY)
-            expected_step_result.add_artifact(name='rekor-uuid', value=TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_UUID)
+            expected_step_result.add_artifact(
+                name='rekor-entry',
+                value=TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_ENTRY
+            )
+            expected_step_result.add_artifact(
+                name='rekor-uuid',
+                value=TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_UUID
+            )
 
-            def upload_mock_side_effect(rekor_server, extra_data_file, signer_pgp_public_key_path, signer_pgp_private_key_user, work_dir_path):
+            def upload_mock_side_effect(
+                rekor_server,
+                extra_data_file,
+                signer_pgp_public_key_path,
+                signer_pgp_private_key_user,
+                work_dir_path
+            ):
                 return TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_ENTRY, TestStepImplementerAutomatedGovernanceRekor.TEST_REKOR_UUID
 
             upload_mock.side_effect = upload_mock_side_effect
 
-            extra_data_file = os.path.join(work_dir_path, 'automated_governance.json')
-            extra_data_file_path = Path(extra_data_file)
-            WorkflowResult().write_results_to_json_file(extra_data_file_path)
+            extra_data_file = os.path.join(
+                work_dir_path,
+                'automated_governance',
+                'automated_governance.json'
+            )
 
             result = step_implementer._run_step()
             upload_mock.assert_called_once_with(
@@ -190,7 +205,7 @@ class TestStepImplementerAutomatedGovernanceRekor(BaseStepImplementerTestCase):
                 extra_data_file=extra_data_file,
                 signer_pgp_public_key_path=signer_pgp_public_key_path,
                 signer_pgp_private_key_user=TestStepImplementerAutomatedGovernanceRekor.TEST_signer_pgp_private_key_user,
-                work_dir_path=work_dir_path
+                work_dir_path=step_implementer.work_dir_path_step
             )
 
             self.assertEqual(result.get_step_result_dict(), expected_step_result.get_step_result_dict())

--- a/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
+++ b/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
@@ -15,7 +15,7 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
             step_name='test',
             implementer='OpenSCAP',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=OpenSCAP,
@@ -23,7 +23,7 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
@@ -34,13 +34,13 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
@@ -54,13 +54,13 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -81,13 +81,13 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -108,13 +108,13 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -129,13 +129,13 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
     def test__validate_required_config_or_previous_step_result_artifact_keys_missing_required_keys(self):
         step_config = {}
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(

--- a/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
+++ b/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
@@ -11,7 +11,7 @@ class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepI
             step_name='test',
             implementer='OpenSCAP',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=OpenSCAP,
@@ -19,5 +19,5 @@ class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepI
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -20,7 +20,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Buildah,
@@ -28,7 +28,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
 # TESTS FOR configuration checks
@@ -59,13 +59,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
@@ -81,7 +81,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_name='create-container-image',
                 implementer='Buildah',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
 
@@ -99,7 +99,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=work_dir_path + '/create-container-image/image-app-name-service-name-1.0-123abc.tar'
+                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar'
             )
 
 
@@ -119,7 +119,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
-                'docker-archive:' + work_dir_path + '/create-container-image/image-app-name-service-name-1.0-123abc.tar',
+                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -129,7 +129,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass_no_container_image_version(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             step_config = {
@@ -146,7 +146,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_config=step_config,
                 step_name='create-container-image',
                 implementer='Buildah',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -162,7 +162,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=work_dir_path + '/create-container-image/image-app-name-service-name-latest.tar'
+                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-latest.tar'
             )
 
             buildah_mock.bud.assert_called_once_with(
@@ -181,7 +181,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:latest',
-                'docker-archive:' + work_dir_path + '/create-container-image/image-app-name-service-name-latest.tar',
+                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-latest.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -191,13 +191,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_pass_image_tar_file_exists(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
@@ -213,7 +213,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_name='create-container-image',
                 implementer='Buildah',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer.write_working_file('image-app-name-service-name-1.0-123abc.tar')
@@ -231,7 +231,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=work_dir_path + '/create-container-image/image-app-name-service-name-1.0-123abc.tar'
+                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar'
             )
 
 
@@ -251,7 +251,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
-                'docker-archive:' + work_dir_path + '/create-container-image/image-app-name-service-name-1.0-123abc.tar',
+                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -261,12 +261,12 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_no_image_spec_file(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'service-name': 'service-name',
@@ -277,7 +277,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_name='create-container-image',
                 implementer='Buildah',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -295,13 +295,13 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_buildah_bud_error(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             image_spec_file = 'Dockerfile'
             step_config = {
@@ -318,7 +318,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_name='create-container-image',
                 implementer='Buildah',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             buildah_mock.bud.side_effect = sh.ErrorReturnCode('buildah', b'mock out', b'mock error')
@@ -343,7 +343,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
     @patch('sh.buildah', create=True)
     def test__run_step_fail_buildah_push_error(self, buildah_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Dockerfile',b'''testing''')
 
             application_name = 'app-name'
@@ -353,7 +353,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             artifact_config = {
                 'container-image-version': {'description': '', 'value': image_tag_version},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'containers-config-auth-file': 'buildah-auth.json',
@@ -369,7 +369,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 step_name='create-container-image',
                 implementer='Buildah',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             buildah_mock.push.side_effect = sh.ErrorReturnCode('buildah', b'mock out', b'mock error')
@@ -377,8 +377,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             result = step_implementer._run_step()
 
             image_tar_path = os.path.join(
-                work_dir_path,
-                'create-container-image',
+                step_implementer.work_dir_path_step,
                 f'image-{application_name}-{service_name}-{image_tag_version}.tar'
             )
             self.assertFalse(result.success)

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -99,7 +99,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar'
+                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar'
             )
 
 
@@ -119,7 +119,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
-                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar',
+                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -162,7 +162,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-latest.tar'
+                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-latest.tar'
             )
 
             buildah_mock.bud.assert_called_once_with(
@@ -181,7 +181,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:latest',
-                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-latest.tar',
+                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-latest.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -231,7 +231,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
             expected_step_result.add_artifact(
                 name='image-tar-file',
-                value=f'{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar'
+                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar'
             )
 
 
@@ -251,7 +251,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             buildah_mock.push.assert_called_once_with(
                 '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
-                f'docker-archive:{step_implementer.work_dir_path_step}/image-app-name-service-name-1.0-123abc.tar',
+                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
@@ -377,7 +377,7 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             result = step_implementer._run_step()
 
             image_tar_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 f'image-{application_name}-{service_name}-{image_tag_version}.tar'
             )
             self.assertFalse(result.success)

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -317,7 +317,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             get_deployment_config_helm_chart_environment_values_file_mock.assert_called_once_with()
             get_app_name_mock.assert_called_once_with()
             deployment_config_repo_dir = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'deployment-config-repo'
             )
             clone_repo_mock.assert_called_once_with(
@@ -461,7 +461,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             get_deployment_config_helm_chart_environment_values_file_mock.assert_called_once_with()
             get_app_name_mock.assert_called_once_with()
             deployment_config_repo_dir = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'deployment-config-repo'
             )
             clone_repo_mock.assert_called_once_with(
@@ -587,7 +587,7 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
             )
             self.assertEqual(updated_file_path, '/does/not/matter/chart/values-PROD.yaml')
             yq_script_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'update-yaml-file-yq-script.yaml'
             )
             yq_mock.write.assert_called_once_with(
@@ -643,7 +643,7 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
                     value=value
                 )
                 yq_script_file_path = os.path.join(
-                    step_implementer.work_dir_path_step,
+                    step_implementer.work_dir_path,
                     'update-yaml-file-yq-script.yaml'
                 )
                 yq_mock.write.assert_called_once_with(
@@ -2173,7 +2173,7 @@ users:
             )
 
             config_argocd_cluster_context_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'config-argocd-cluster-context.yaml'
             )
             argocd_mock.cluster.add.assert_called_once_with(
@@ -2230,7 +2230,7 @@ users:
             )
 
             config_argocd_cluster_context_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'config-argocd-cluster-context.yaml'
             )
             argocd_mock.cluster.add.assert_called_once_with(
@@ -2303,7 +2303,7 @@ users:
                 )
 
                 config_argocd_cluster_context_file_path = os.path.join(
-                    step_implementer.work_dir_path_step,
+                    step_implementer.work_dir_path,
                     'config-argocd-cluster-context.yaml'
                 )
                 argocd_mock.cluster.add.assert_called_once_with(

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -17,7 +17,7 @@ class TestStepImplementerDeployArgoCDBase(BaseStepImplementerTestCase):
     def create_step_implementer(
         self,
         step_config={},
-        work_dir_path='',
+        parent_work_dir_path='',
         environment=None
     ):
         return self.create_given_step_implementer(
@@ -25,7 +25,7 @@ class TestStepImplementerDeployArgoCDBase(BaseStepImplementerTestCase):
             step_config=step_config,
             step_name='deploy',
             implementer='ArgoCD',
-            work_dir_path=work_dir_path,
+            parent_work_dir_path=parent_work_dir_path,
             environment=environment
         )
 
@@ -67,7 +67,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 ):
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_success_ssh(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -82,14 +82,14 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_success_https(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -106,14 +106,14 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_username(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -129,7 +129,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -140,7 +140,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_password(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -156,7 +156,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -167,7 +167,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_https_no_git_creds(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -182,7 +182,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -195,7 +195,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
 
     def test_ArgoCD_validate_required_config_or_previous_step_result_artifact_keys_fail_http_no_git_creds(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -210,7 +210,7 @@ class TestStepImplementerDeployArgoCD_validate_required_config_or_previous_step_
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -269,7 +269,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
         argocd_get_app_manifest_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -284,7 +284,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 environment='PROD'
             )
 
@@ -317,9 +317,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             get_deployment_config_helm_chart_environment_values_file_mock.assert_called_once_with()
             get_app_name_mock.assert_called_once_with()
             deployment_config_repo_dir = os.path.join(
-                work_dir_path,
-                'deploy',
-                'PROD',
+                step_implementer.work_dir_path_step,
                 'deployment-config-repo'
             )
             clone_repo_mock.assert_called_once_with(
@@ -421,7 +419,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
         argocd_get_app_manifest_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'argocd-username': 'argo-username',
                 'argocd-password': 'argo-password',
@@ -436,7 +434,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 environment='PROD'
             )
 
@@ -463,9 +461,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             get_deployment_config_helm_chart_environment_values_file_mock.assert_called_once_with()
             get_app_name_mock.assert_called_once_with()
             deployment_config_repo_dir = os.path.join(
-                work_dir_path,
-                'deploy',
-                'PROD',
+                step_implementer.work_dir_path_step,
                 'deployment-config-repo'
             )
             clone_repo_mock.assert_called_once_with(
@@ -491,13 +487,13 @@ class TestStepImplementerDeployArgoCD__get_container_image_version(
 ):
     def test_ArgoCD__get_container_image_version_config_value(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'container-image-version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             image_version = step_implementer._ArgoCD__get_container_image_version()
@@ -505,12 +501,12 @@ class TestStepImplementerDeployArgoCD__get_container_image_version(
 
     def test_ArgoCD__get_container_image_version_no_config_value(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             image_version = step_implementer._ArgoCD__get_container_image_version()
@@ -521,13 +517,13 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 ):
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_config_value(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'deployment-config-helm-chart-environment-values-file': 'values-AWEOMSE.yaml'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             deployment_config_helm_chart_env_value_file = \
@@ -539,12 +535,12 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_no_config_value_no_env(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             deployment_config_helm_chart_env_value_file = \
@@ -556,12 +552,12 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_helm_chart_environm
 
     def test_ArgoCD__get_deployment_config_helm_chart_environment_values_file_no_config_value_with_env(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 environment='PROD'
             )
 
@@ -576,12 +572,12 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
     @patch('sh.yq', create=True)
     def test_ArgoCD__update_yaml_file_value_success(self, yq_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             updated_file_path = step_implementer._ArgoCD__update_yaml_file_value(
@@ -591,8 +587,7 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
             )
             self.assertEqual(updated_file_path, '/does/not/matter/chart/values-PROD.yaml')
             yq_script_file_path = os.path.join(
-                work_dir_path,
-                'deploy',
+                step_implementer.work_dir_path_step,
                 'update-yaml-file-yq-script.yaml'
             )
             yq_mock.write.assert_called_once_with(
@@ -614,12 +609,12 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
     @patch('sh.yq', create=True)
     def test_ArgoCD__update_yaml_file_value_fail(self, yq_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             yq_mock.write.side_effect = create_sh_side_effect(
@@ -648,8 +643,7 @@ class TestStepImplementerDeployArgoCD__update_yaml_file_value(TestStepImplemente
                     value=value
                 )
                 yq_script_file_path = os.path.join(
-                    work_dir_path,
-                    'deploy',
+                    step_implementer.work_dir_path_step,
                     'update-yaml-file-yq-script.yaml'
                 )
                 yq_mock.write.assert_called_once_with(
@@ -672,14 +666,14 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_http(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
                 'git-password': 'test-password'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._ArgoCD__git_tag_and_push_deployment_config_repo(
@@ -698,14 +692,14 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_https(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
                 'git-password': 'test-password'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._ArgoCD__git_tag_and_push_deployment_config_repo(
@@ -724,14 +718,14 @@ class TestStepImplementerDeployArgoCD__git_tag_and_push_deployment_config_repo(T
     @patch.object(ArgoCD, '_ArgoCD__git_tag_and_push')
     def test_ArgoCD__git_tag_and_push_deployment_config_repo_ssh(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'git-username': 'test-username',
                 'git-password': 'test-password'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._ArgoCD__git_tag_and_push_deployment_config_repo(
@@ -751,7 +745,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_no_env_less_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
                 'application-name': 'test-app',
@@ -759,7 +753,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             app_name = step_implementer._ArgoCD__get_app_name()
@@ -768,7 +762,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/TEST')
     def test_ArgoCD__get_app_name_no_env_less_then_max_length_caps(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -776,7 +770,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             app_name = step_implementer._ArgoCD__get_app_name()
@@ -785,7 +779,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_no_env_more_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
                 'application-name': 'test-app',
@@ -793,7 +787,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             app_name = step_implementer._ArgoCD__get_app_name()
@@ -802,7 +796,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
     @patch.object(ArgoCD, '_ArgoCD__get_repo_branch', return_value='feature/test')
     def test_ArgoCD__get_app_name_with_env_less_then_max_length(self, get_repo_branch_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-org',
                 'application-name': 'test-app',
@@ -810,7 +804,7 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 environment='PROD'
             )
 
@@ -820,14 +814,14 @@ class TestStepImplementerDeployArgoCD__get_app_name(TestStepImplementerDeployArg
 class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepImplementerDeployArgoCDBase):
     def test_ArgoCD__get_deployment_config_repo_tag_use_tag(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'tag': 'v0.42.0-abc123',
                 'version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             deployment_config_repo_tag = step_implementer._ArgoCD__get_deployment_config_repo_tag()
@@ -835,13 +829,13 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_version(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             deployment_config_repo_tag = step_implementer._ArgoCD__get_deployment_config_repo_tag()
@@ -850,12 +844,12 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_latest(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             deployment_config_repo_tag = step_implementer._ArgoCD__get_deployment_config_repo_tag()
@@ -863,14 +857,14 @@ class TestStepImplementerDeployArgoCD__get_deployment_config_repo_tag(TestStepIm
 
     def test_ArgoCD__get_deployment_config_repo_tag_use_tag_with_env(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'tag': 'v0.42.0-main+abc123',
                 'version': 'v0.42.0'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 environment='PROD'
             )
 
@@ -2130,10 +2124,10 @@ class TestStepImplementerDeployArgoCD__argocd_add_target_cluster(TestStepImpleme
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_default_cluster(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._ArgoCD__argocd_add_target_cluster(
@@ -2146,10 +2140,10 @@ class TestStepImplementerDeployArgoCD__argocd_add_target_cluster(TestStepImpleme
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_custom_cluster_kube_skip_tls_true(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
 apiVersion: v1
@@ -2179,8 +2173,7 @@ users:
             )
 
             config_argocd_cluster_context_file_path = os.path.join(
-                work_dir_path,
-                'deploy',
+                step_implementer.work_dir_path_step,
                 'config-argocd-cluster-context.yaml'
             )
             argocd_mock.cluster.add.assert_called_once_with(
@@ -2204,10 +2197,10 @@ users:
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_custom_cluster_kube_skip_tls_false(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
 apiVersion: v1
@@ -2237,8 +2230,7 @@ users:
             )
 
             config_argocd_cluster_context_file_path = os.path.join(
-                work_dir_path,
-                'deploy',
+                step_implementer.work_dir_path_step,
                 'config-argocd-cluster-context.yaml'
             )
             argocd_mock.cluster.add.assert_called_once_with(
@@ -2262,10 +2254,10 @@ users:
     @patch('sh.argocd', create=True)
     def test_ArgoCD__argocd_add_target_cluster_fail_custom_cluster_kube_skip_tls_true(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
             expected_config_argocd_cluster_context_file_contents = """---
 apiVersion: v1
@@ -2311,8 +2303,7 @@ users:
                 )
 
                 config_argocd_cluster_context_file_path = os.path.join(
-                    work_dir_path,
-                    'deploy',
+                    step_implementer.work_dir_path_step,
                     'config-argocd-cluster-context.yaml'
                 )
                 argocd_mock.cluster.add.assert_called_once_with(
@@ -2624,10 +2615,10 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_success_live(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             arogcd_app_manifest_file = step_implementer._ArgoCD__argocd_get_app_manifest(
@@ -2646,10 +2637,10 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_success_git(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             arogcd_app_manifest_file = step_implementer._ArgoCD__argocd_get_app_manifest(
@@ -2668,11 +2659,11 @@ class TestStepImplementerDeployArgoCD__argocd_get_app_manifest(TestStepImplement
     @patch('sh.argocd', create=True)
     def test___argocd_get_app_manifest_fail(self, argocd_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config={},
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             argocd_mock.app.manifests.side_effect = create_sh_side_effect(

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -19,7 +19,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Git,
@@ -27,7 +27,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -45,7 +45,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
             create_git_commit_with_sample_file(temp_dir, repo)
@@ -58,7 +58,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -68,7 +68,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_root_dir_is_not_git_repo(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'repo-root': '/'
             }
@@ -77,7 +77,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -94,7 +94,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_root_dir_is_bare_git_repo(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             Repo.init(str(temp_dir.path), bare=True)
 
             step_config = {
@@ -105,7 +105,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -122,7 +122,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_no_commit_history(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             Repo.init(str(temp_dir.path))
 
             step_config = {
@@ -133,7 +133,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -155,7 +155,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_git_repo_with_single_commit_on_master(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
             create_git_commit_with_sample_file(temp_dir, repo)
@@ -168,7 +168,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -178,7 +178,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_git_repo_with_single_commit_on_feature(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
             create_git_commit_with_sample_file(temp_dir, repo)
@@ -195,7 +195,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -206,7 +206,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_directory_is_detached(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             repo = Repo.init(str(temp_dir.path))
 
             # create commits
@@ -224,7 +224,7 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Git',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_maven_generate_metadata.py
@@ -17,7 +17,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Maven,
@@ -25,7 +25,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -42,7 +42,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -59,14 +59,14 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_package_file_does_not_exist(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
 
@@ -77,7 +77,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -88,7 +88,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -105,7 +105,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -121,7 +121,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_version_in_pom_file(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
@@ -137,7 +137,7 @@ class TestStepImplementerMavenGenerateMetadata(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/generate_metadata/test_npm_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_npm_generate_metadata.py
@@ -14,7 +14,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Npm,
@@ -22,7 +22,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -41,7 +41,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             temp_dir.write('package.json', b'''{
               "name": "my-awesome-package",
@@ -57,14 +57,14 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='test',
                 implementer='Npm',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_package_file_does_not_exist(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             package_file_path = os.path.join(temp_dir.path, 'package.json')
             step_config = {
                 'package-file': package_file_path
@@ -74,7 +74,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='test',
                 implementer='Npm',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -85,7 +85,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('package.json', b'''{
               "name": "my-awesome-package",
               "version": "42.1"
@@ -98,7 +98,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Npm',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -115,7 +115,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_version_in_package_file(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('package.json', b'''{
               "name": "my-awesome-package"
             }''')
@@ -127,7 +127,7 @@ class TestStepImplementerGenerateMetadataNpm(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='Npm',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -18,7 +18,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=SemanticVersion,
@@ -26,7 +26,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -48,7 +48,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
 
@@ -57,14 +57,14 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
                 'pre-release': {'description': '', 'value': 'master'},
                 'build': {'description': '', 'value': 'abc123'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='SemanticVersion',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -81,7 +81,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
 
     def test_run_step_pass_different_pre_release(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
 
@@ -90,14 +90,14 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
                 'pre-release': {'description': '', 'value': 'feature123'},
                 'build': {'description': '', 'value': 'abc123'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
                 implementer='SemanticVersion',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -21,7 +21,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Maven,
@@ -29,7 +29,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     # TESTS FOR configuration checks
@@ -85,7 +85,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'war'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -103,7 +103,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = TestStepImplementerMavenPackageBase.create_mvn_side_effect(
@@ -127,8 +127,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -145,7 +144,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'jar'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -162,7 +161,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = TestStepImplementerMavenPackageBase.create_mvn_side_effect(
@@ -182,8 +181,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result = StepResult(step_name='package', sub_step_name='Maven', sub_step_implementer_name='Maven')
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -198,7 +196,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail_no_pom(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {}
 
@@ -206,7 +204,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -220,7 +218,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail_mvn_error(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -235,7 +233,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = sh.ErrorReturnCode('mvn', b'mock out', b'mock error')
@@ -249,8 +247,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 sub_step_implementer_name='Maven'
             )
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -278,7 +275,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'jar'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -295,7 +292,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = TestStepImplementerMavenPackageBase.create_mvn_side_effect(
@@ -313,8 +310,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = "pom resulted in multiple artifacts with expected artifact extensions (['jar', 'war', 'ear']), this is unsupported"
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -330,7 +326,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = ''
             version = ''
             package = ''
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml',b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -347,7 +343,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = TestStepImplementerMavenPackageBase.create_mvn_side_effect(
@@ -362,8 +358,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = "pom resulted in 0 with expected artifact extensions (['jar', 'war', 'ear']), this is unsupported"
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -380,7 +375,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             artifact_id = 'my-app'
             version = '1.0'
             package = 'war'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('pom.xml', b'''<project>
                 <modelVersion>4.0.0</modelVersion>
                 <groupId>com.mycompany.app</groupId>
@@ -401,7 +396,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='package',
                 implementer='Maven',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             mvn_mock.side_effect = TestStepImplementerMavenPackageBase.create_mvn_side_effect(
@@ -425,8 +420,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'package',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/package/test_maven_package.py
+++ b/tests/step_implementers/package/test_maven_package.py
@@ -127,7 +127,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -181,7 +181,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result = StepResult(step_name='package', sub_step_name='Maven', sub_step_implementer_name='Maven')
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -247,7 +247,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
                 sub_step_implementer_name='Maven'
             )
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -310,7 +310,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = "pom resulted in multiple artifacts with expected artifact extensions (['jar', 'war', 'ear']), this is unsupported"
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -358,7 +358,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = "pom resulted in 0 with expected artifact extensions (['jar', 'war', 'ear']), this is unsupported"
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -420,7 +420,7 @@ class TestStepImplementerMavenPackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='package-artifacts', value=[package_artifacts])
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -20,7 +20,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Maven,
@@ -28,7 +28,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -51,7 +51,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_pass(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
                 'maven-push-artifact-repo-url': 'pass',
@@ -69,7 +69,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
@@ -77,7 +77,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 step_name='push-artifacts',
                 implementer='Maven',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
             result = step_implementer._run_step()
 
@@ -96,8 +96,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='push-artifacts', value=push_artifacts)
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'push-artifacts',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -110,7 +109,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_fail(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             # config
             step_config = {
@@ -129,7 +128,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
@@ -137,7 +136,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 step_name='push-artifacts',
                 implementer='Maven',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
             sh.mvn.side_effect = sh.ErrorReturnCode('mvn', b'mock out', b'mock error')
 
@@ -153,8 +152,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 value=[]
             )
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'push-artifacts',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -179,7 +177,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
     @patch('sh.mvn', create=True)
     def test_run_step_tls_verify_false(self, mvn_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
                 'maven-push-artifact-repo-url': 'pass',
@@ -198,7 +196,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 'package-artifacts': {'value': package_artifacts},
                 'version': {'value': 'test-version'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             # Actual results
             step_implementer = self.create_step_implementer(
@@ -206,7 +204,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 step_name='push-artifacts',
                 implementer='Maven',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
             result = step_implementer._run_step()
 
@@ -225,8 +223,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='push-artifacts', value=push_artifacts)
             mvn_output_file_path = os.path.join(
-                work_dir_path,
-                'push-artifacts',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_maven_push_artifacts.py
@@ -96,7 +96,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='push-artifacts', value=push_artifacts)
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -152,7 +152,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
                 value=[]
             )
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(
@@ -223,7 +223,7 @@ class TestStepImplementerMavenPushArtifacts(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='push-artifacts', value=push_artifacts)
             mvn_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
+++ b/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
@@ -23,7 +23,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Skopeo,
@@ -31,7 +31,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -61,7 +61,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
     @patch.object(sh, 'skopeo', create=True)
     def test_run_step_pass(self, skopeo_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             image_tar_file = 'fake-image.tar'
             image_version = '1.0-69442c8'
@@ -78,7 +78,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='push-container-image',
                 implementer='Skopeo',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -132,7 +132,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
     @patch.object(sh, 'skopeo', create=True)
     def test_run_step_fail_run_skopeo(self, skopeo_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             image_tar_file = 'fake-image.tar'
             image_version = '1.0-69442c8'
@@ -149,7 +149,7 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='push-container-image',
                 implementer='Skopeo',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             skopeo_mock.copy.side_effect = sh.ErrorReturnCode('skopeo', b'mock stdout', b'mock error')

--- a/tests/step_implementers/report/test_result_artifacts_archive.py
+++ b/tests/step_implementers/report/test_result_artifacts_archive.py
@@ -17,7 +17,7 @@ class TestStepImplementerResultArtifactsArchiveBase(BaseStepImplementerTestCase)
             self,
             step_config={},
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=ResultArtifactsArchive,
@@ -25,7 +25,7 @@ class TestStepImplementerResultArtifactsArchiveBase(BaseStepImplementerTestCase)
             step_name='report',
             implementer='ResultArtifactsArchive',
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
 class TestStepImplementerResultArtifactsArchive_other(TestStepImplementerResultArtifactsArchiveBase):
@@ -59,7 +59,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
     )
     def test__run_step_pass_no_archive(self, create_archive_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -68,7 +68,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_result = step_implementer._run_step()
@@ -93,7 +93,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
     )
     def test__run_step_pass(self, create_archive_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -102,7 +102,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_result = step_implementer._run_step()
@@ -128,7 +128,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
     )
     def test__run_step_pass_upload_to_file(self, create_archive_mock, upload_file_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -138,7 +138,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             # mock the upload results
@@ -187,7 +187,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
     )
     def test__run_step_pass_upload_to_remote_with_auth(self, create_archive_mock, upload_file_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -199,7 +199,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             # mock the upload results
@@ -248,7 +248,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
     )
     def test__run_step_pass_upload_to_remote_with_auth_failure(self, create_archive_mock, upload_file_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -260,7 +260,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             # mock the upload results
@@ -301,7 +301,7 @@ class TestStepImplementerResultArtifactsArchive_run_step(TestStepImplementerResu
 class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplementerResultArtifactsArchiveBase):
     def test___create_archive_no_results(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -310,7 +310,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             archive_path = step_implementer._ResultArtifactsArchive__create_archive()
@@ -319,7 +319,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_string_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -339,7 +339,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             workflow_result.add_step_result(step_result)
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -357,7 +357,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_file_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -383,7 +383,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -402,7 +402,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_dir_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -433,7 +433,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -461,7 +461,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_list_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -485,7 +485,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             workflow_result.add_step_result(step_result)
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -510,7 +510,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_dict_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -534,7 +534,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             workflow_result.add_step_result(step_result)
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -559,7 +559,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_bool_result(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -579,7 +579,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             workflow_result.add_step_result(step_result)
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -600,7 +600,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_string_result_with_env(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -621,7 +621,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             workflow_result.add_step_result(step_result)
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 
@@ -639,7 +639,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
     def test___create_archive_file_result_with_env(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = {
                 'organization': 'test-ORG',
                 'application-name': 'test-APP',
@@ -666,7 +666,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
                 workflow_result=workflow_result
             )
 

--- a/tests/step_implementers/shared/test_maven_generic.py
+++ b/tests/step_implementers/shared/test_maven_generic.py
@@ -90,7 +90,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             self.assertEqual(expected_settings_xml_path, actual_settings_xml_path)
 
             utils_generate_maven_settings_mock.assert_called_once_with(
-                working_dir=step_implementer.work_dir_path_step,
+                working_dir=step_implementer.work_dir_path,
                 maven_servers=maven_servers,
                 maven_repositories=maven_repositories,
                 maven_mirrors=maven_mirrors
@@ -162,7 +162,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
 
             # first call
-            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
@@ -193,7 +193,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
 
             # first call
-            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
@@ -203,7 +203,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             # second call
             write_effective_pom_mock.reset_mock()
-            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_not_called()

--- a/tests/step_implementers/shared/test_maven_generic.py
+++ b/tests/step_implementers/shared/test_maven_generic.py
@@ -29,7 +29,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             self,
             step_config={},
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=SampleMavenStepImplementer,
@@ -37,13 +37,13 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             step_name='foo',
             implementer='SampleMavenStepImplementer',
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.generate_maven_settings')
     def test__generate_maven_settings(self, utils_generate_maven_settings_mock):
         with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
             maven_servers = {
                 "internal-mirror": {
                     "id": "internal-server",
@@ -72,7 +72,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             expected_settings_xml_path = '/does/not/matter/settings.xml'
@@ -100,7 +100,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
         with TempDirectory() as test_dir:
             results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             results_file_name = 'step-runner-results.yml'
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
             step_config = {
@@ -110,7 +110,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             Path(pom_file_path).touch()
@@ -120,7 +120,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
         with TempDirectory() as test_dir:
             results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             results_file_name = 'step-runner-results.yml'
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
             step_config = {
@@ -130,7 +130,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -142,7 +142,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.write_effective_pom')
     def test__get_effective_pom_call_once(self, write_effective_pom_mock):
         with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
             step_config = {
@@ -151,7 +151,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             # mock effective pom
@@ -173,7 +173,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.write_effective_pom')
     def test__get_effective_pom_call_twice(self, write_effective_pom_mock):
         with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
             step_config = {
@@ -182,7 +182,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             # mock effective pom
@@ -214,7 +214,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
         with TempDirectory() as test_dir:
             results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
             results_file_name = 'step-runner-results.yml'
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
             step_config = {
@@ -223,7 +223,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             def get_effective_pom_side_effect():

--- a/tests/step_implementers/shared/test_maven_generic.py
+++ b/tests/step_implementers/shared/test_maven_generic.py
@@ -43,8 +43,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.generate_maven_settings')
     def test__generate_maven_settings(self, utils_generate_maven_settings_mock):
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
             maven_servers = {
                 "internal-mirror": {
@@ -92,7 +90,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             self.assertEqual(expected_settings_xml_path, actual_settings_xml_path)
 
             utils_generate_maven_settings_mock.assert_called_once_with(
-                working_dir=work_dir_path,
+                working_dir=step_implementer.work_dir_path_step,
                 maven_servers=maven_servers,
                 maven_repositories=maven_repositories,
                 maven_mirrors=maven_mirrors
@@ -144,8 +142,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.write_effective_pom')
     def test__get_effective_pom_call_once(self, write_effective_pom_mock):
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
@@ -166,7 +162,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
 
             # first call
-            expected_effective_pom_path = os.path.join(work_dir_path, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
@@ -177,8 +173,6 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
     @patch('ploigos_step_runner.step_implementers.shared.maven_generic.write_effective_pom')
     def test__get_effective_pom_call_twice(self, write_effective_pom_mock):
         with TempDirectory() as test_dir:
-            results_dir_path = os.path.join(test_dir.path, 'step-runner-results')
-            results_file_name = 'step-runner-results.yml'
             work_dir_path = os.path.join(test_dir.path, 'working')
 
             pom_file_path = os.path.join(test_dir.path, 'pom.xml')
@@ -199,7 +193,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
 
             # first call
-            expected_effective_pom_path = os.path.join(work_dir_path, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
@@ -209,7 +203,7 @@ class TestStepImplementerSharedMavenGeneric(BaseStepImplementerTestCase):
 
             # second call
             write_effective_pom_mock.reset_mock()
-            expected_effective_pom_path = os.path.join(work_dir_path, 'effective-pom.xml')
+            expected_effective_pom_path = os.path.join(step_implementer.work_dir_path_step, 'effective-pom.xml')
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_not_called()

--- a/tests/step_implementers/shared/test_openscap_generic.py
+++ b/tests/step_implementers/shared/test_openscap_generic.py
@@ -1024,15 +1024,15 @@ Result	pass
             expected_results.success=True
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, step_result)
 
@@ -1124,15 +1124,15 @@ Result	fail
                 "\nIdent\tCCE-82985-3\nResult\tfail\n"
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, step_result)
 
@@ -1218,15 +1218,15 @@ Result	fail
             expected_results.success=True
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, result)
 

--- a/tests/step_implementers/shared/test_openscap_generic.py
+++ b/tests/step_implementers/shared/test_openscap_generic.py
@@ -24,7 +24,7 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=OpenSCAPGeneric,
@@ -32,7 +32,7 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -57,13 +57,13 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
@@ -75,13 +75,13 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
             'image-tar-file': 'does-not-matter'
         }
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -102,13 +102,13 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -123,13 +123,13 @@ class TestStepImplementerSharedOpenSCAPGeneric(BaseStepImplementerTestCase):
     def test__validate_required_config_or_previous_step_result_artifact_keys_missing_required_keys(self):
         step_config = {}
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             with self.assertRaisesRegex(
@@ -989,20 +989,20 @@ Result	pass
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1024,15 +1024,15 @@ Result	pass
             expected_results.success=True
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, step_result)
 
@@ -1086,20 +1086,20 @@ Result	fail
 """
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1124,15 +1124,15 @@ Result	fail
                 "\nIdent\tCCE-82985-3\nResult\tfail\n"
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, step_result)
 
@@ -1183,20 +1183,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1218,15 +1218,15 @@ Result	fail
             expected_results.success=True
             expected_results.add_artifact(
                 name='html-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-report.html"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-report.html"
             )
             expected_results.add_artifact(
                 name='xml-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-results.xml"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-results.xml"
             )
             expected_results.add_artifact(
                 name='stdout-report',
-                value=f"{work_dir_path}/test/oscap-xccdf-out"
+                value=f"{step_implementer.work_dir_path_step}/oscap-xccdf-out"
             )
             self.assertEqual(expected_results, result)
 
@@ -1277,20 +1277,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type
@@ -1361,20 +1361,20 @@ Result	fail
         oscap_eval_fails = None
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             mount_path = '/does/not/matter/container-mount'
 
             artifact_config = {
                 'image-tar-file': {'description': '', 'value': image_tar_file}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='test',
                 implementer='OpenSCAP',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             get_oscap_document_type_mock.return_value = oscap_document_type

--- a/tests/step_implementers/sign_container_image/test_podman_sign.py
+++ b/tests/step_implementers/sign_container_image/test_podman_sign.py
@@ -75,7 +75,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=PodmanSign,
@@ -83,7 +83,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -103,7 +103,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_pass(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             container_image_tag = 'does/not/matter:v0.42.0'
@@ -113,7 +113,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -133,7 +133,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -143,7 +143,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
                 image_signatures_directory= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature'
                 ),
                 container_image_tag=container_image_tag
@@ -157,7 +157,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
                 value= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature',
                     signature_name
                 )
@@ -182,7 +182,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
         upload_file_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             step_config['container-image-signature-destination-url'] = '/mock/container-sigs'
@@ -193,7 +193,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -215,7 +215,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -225,7 +225,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
                 image_signatures_directory= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature'
                 ),
                 container_image_tag=container_image_tag
@@ -245,7 +245,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
                 value= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature',
                     signature_name
                 )
@@ -282,7 +282,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
         upload_file_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             step_config['container-image-signature-destination-url'] = \
@@ -296,7 +296,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -318,7 +318,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -328,7 +328,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
                 image_signatures_directory= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature'
                 ),
                 container_image_tag=container_image_tag
@@ -348,7 +348,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
                 value= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature',
                     signature_name
                 )
@@ -385,7 +385,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
         upload_file_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             step_config['container-image-signature-destination-url'] = \
@@ -399,7 +399,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -421,7 +421,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -432,7 +432,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
                 image_signatures_directory= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature'
                 ),
                 container_image_tag=container_image_tag
@@ -452,7 +452,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
                 value= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature',
                     signature_name
                 )
@@ -480,7 +480,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_fail_import_pgp_key(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             container_image_tag = 'does/not/matter:v0.42.0'
             signature_name = 'does/not/matter/signature-0'
@@ -489,7 +489,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             import_pgp_key_mock.side_effect = RuntimeError('mock error importing pgp key')
 
@@ -508,7 +508,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -532,7 +532,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_fail_sign_image(self, sign_image_mock, import_pgp_key_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             pgp_private_key_fingerprint = 'abc123'
             step_config = TestStepImplementerSignContainerImagePodman.generate_config()
             container_image_tag = 'does/not/matter:v0.42.0'
@@ -541,7 +541,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             artifact_config = {
                 'container-image-tag': {'value': container_image_tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             def import_pgp_key_side_effect(pgp_private_key):
                 return pgp_private_key_fingerprint
@@ -555,7 +555,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 implementer='PodmanSign',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -565,7 +565,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             sign_image_mock.assert_called_once_with(
                 pgp_private_key_fingerprint=pgp_private_key_fingerprint,
                 image_signatures_directory= os.path.join(
-                    work_dir_path,
+                    parent_work_dir_path,
                     'sign-container-image/image-signature'
                 ),
                 container_image_tag=container_image_tag

--- a/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
+++ b/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
@@ -168,7 +168,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.projectKey=app-name:service-name',
                     '-Dsonar.login=username',
                     '-Dsonar.password=password',
-                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path,
                     _env={'SONAR_SCANNER_OPTS': '-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts'},
                     _out=sys.stdout,
                     _err=sys.stderr
@@ -220,7 +220,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.host.url=https://sonarqube-sonarqube.apps.ploigos_step_runner.rht-set.com',
                     '-Dsonar.projectVersion=1.0-123abc',
                     '-Dsonar.projectKey=app-name:service-name',
-                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path,
                     _env={'SONAR_SCANNER_OPTS': '-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts'},
                     _out=sys.stdout,
                     _err=sys.stderr
@@ -316,7 +316,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.projectKey=app-name:service-name',
                     '-Dsonar.login=username',
                     '-Dsonar.password=password',
-                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path,
                     _env={'SONAR_SCANNER_OPTS': f'-Djavax.net.ssl.trustStore={java_truststore}'},
                     _out=sys.stdout,
                     _err=sys.stderr

--- a/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
+++ b/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
@@ -22,7 +22,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=SonarQube,
@@ -30,7 +30,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
 # TESTS FOR configuration checks
@@ -63,13 +63,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
         }
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
@@ -83,13 +83,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             'version': 'notused'
         }
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
             with self.assertRaisesRegex(
                 StepRunnerException,
@@ -106,13 +106,13 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             'version': 'notused'
         }
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='static-code-analysis',
                 implementer='SonarQube',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
             with self.assertRaisesRegex(
                 StepRunnerException,
@@ -123,14 +123,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
 
             artifact_config = {
                 'version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -146,7 +146,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 step_name='static-code-analysis',
                 implementer='SonarQube',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -179,14 +179,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass_no_username_and_password(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
 
             artifact_config = {
                 'version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -200,7 +200,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 step_name='static-code-analysis',
                 implementer='SonarQube',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -231,12 +231,12 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_fail_no_properties(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': 'https://sonarqube-sonarqube.apps.ploigos_step_runner.rht-set.com',
@@ -249,7 +249,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 step_name='static-code-analysis',
                 implementer='SonarQube',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -267,7 +267,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
     @patch('sh.sonar_scanner', create=True)
     def test_run_step_pass_alternate_java_truststore(self, sonar_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties', b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
             temp_dir.write('alternate.jks', b'''testing''')
@@ -276,7 +276,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             artifact_config = {
                 'version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -292,7 +292,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 step_name='static-code-analysis',
                 implementer='SonarQube',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
 
@@ -331,14 +331,14 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
         sonar_mock
     ):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('sonar-project.properties',b'''testing''')
             properties_path = os.path.join(temp_dir.path, 'sonar-project.properties')
 
             artifact_config = {
                 'version': {'description': '', 'value': '1.0-123abc'},
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'properties': properties_path,
@@ -354,7 +354,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                 step_name='static-code-analysis',
                 implementer='SonarQube',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             sonar_mock.side_effect = sonar_scanner_error

--- a/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
+++ b/tests/step_implementers/static_code_analysis/test_sonarqube_static_code_analysis.py
@@ -158,7 +158,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(
                 name='sonarqube-result-set',
-                value=f'{temp_dir.path}/working/report-task.txt'
+                value=f'{temp_dir.path}/working/static-code-analysis/report-task.txt'
             )
 
             sonar_mock.assert_called_once_with(
@@ -168,7 +168,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.projectKey=app-name:service-name',
                     '-Dsonar.login=username',
                     '-Dsonar.password=password',
-                    '-Dsonar.working.directory=' + work_dir_path,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
                     _env={'SONAR_SCANNER_OPTS': '-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts'},
                     _out=sys.stdout,
                     _err=sys.stderr
@@ -212,7 +212,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(
                 name='sonarqube-result-set',
-                value=f'{temp_dir.path}/working/report-task.txt'
+                value=f'{temp_dir.path}/working/static-code-analysis/report-task.txt'
             )
 
             sonar_mock.assert_called_once_with(
@@ -220,7 +220,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.host.url=https://sonarqube-sonarqube.apps.ploigos_step_runner.rht-set.com',
                     '-Dsonar.projectVersion=1.0-123abc',
                     '-Dsonar.projectKey=app-name:service-name',
-                    '-Dsonar.working.directory=' + work_dir_path,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
                     _env={'SONAR_SCANNER_OPTS': '-Djavax.net.ssl.trustStore=/etc/pki/java/cacerts'},
                     _out=sys.stdout,
                     _err=sys.stderr
@@ -306,7 +306,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(
                 name='sonarqube-result-set',
-                value=f'{temp_dir.path}/working/report-task.txt'
+                value=f'{temp_dir.path}/working/static-code-analysis/report-task.txt'
             )
 
             sonar_mock.assert_called_once_with(
@@ -316,7 +316,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
                     '-Dsonar.projectKey=app-name:service-name',
                     '-Dsonar.login=username',
                     '-Dsonar.password=password',
-                    '-Dsonar.working.directory=' + work_dir_path,
+                    '-Dsonar.working.directory=' + step_implementer.work_dir_path_step,
                     _env={'SONAR_SCANNER_OPTS': f'-Djavax.net.ssl.trustStore={java_truststore}'},
                     _out=sys.stdout,
                     _err=sys.stderr
@@ -369,7 +369,7 @@ class TestStepImplementerSonarQubePackageBase(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.add_artifact(
                 name='sonarqube-result-set',
-                value=f'{temp_dir.path}/working/report-task.txt'
+                value=f'{temp_dir.path}/working/static-code-analysis/report-task.txt'
             )
 
             self.assertEqual(result.success, expected_step_result.success)

--- a/tests/step_implementers/tag_source/test_git_tag_source.py
+++ b/tests/step_implementers/tag_source/test_git_tag_source.py
@@ -21,7 +21,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         self,
         workflow_result=None,
         step_config={},
-        work_dir_path=''
+        parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Git,
@@ -29,7 +29,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_name='tag-source',
             implementer='Git',
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
 # TESTS FOR configuration checks
@@ -45,7 +45,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
          with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
                 'git-username': 'git-username',
@@ -53,21 +53,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_username(self):
          with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
                 'git-password': 'git-password'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -78,14 +78,14 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_password(self):
          with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             step_config = {
                 'git-username': 'git-username'
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -105,7 +105,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             step_config = {
                 'url': url,
@@ -118,12 +118,12 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 'container-image-version': {'description': '', 'value': tag}
             }
 
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             def get_tag_side_effect():
@@ -156,12 +156,12 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
@@ -171,7 +171,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -204,13 +204,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
@@ -220,7 +220,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -253,13 +253,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url
@@ -267,7 +267,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -300,13 +300,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url
@@ -314,7 +314,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -347,13 +347,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url
@@ -361,7 +361,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -393,13 +393,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
@@ -409,7 +409,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -447,13 +447,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
@@ -463,7 +463,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -498,13 +498,13 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url,
@@ -514,7 +514,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def get_tag_side_effect():
@@ -556,12 +556,12 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         with TempDirectory() as temp_dir:
             tag = 'latest'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': tag}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': url
@@ -569,7 +569,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             def git_url_side_effect():
@@ -603,18 +603,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         remote_origin_url = "https://does.not.matter.xyz/foo.git"
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             git_mock.config.side_effect = TestStepImplementerTagSourceGit.\
@@ -627,18 +627,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
     @patch('sh.git', create=True)
     def test__git_url_url_from_git_config_error(self, git_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             git_mock.config.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
@@ -654,12 +654,12 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         remote_origin_url = "https://does.not.matter.xyz/foo.git"
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
                 'url': remote_origin_url
@@ -667,7 +667,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             git_mock.assert_not_called()
@@ -683,18 +683,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         git_tag_value = "1.0+69442c8"
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._Git__git_tag(git_tag_value)
@@ -712,18 +712,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         git_tag_value = "1.0+69442c8"
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             git_mock.tag.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
@@ -741,18 +741,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         url = 'www.xyz.com'
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._Git__git_push(url)
@@ -769,18 +769,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
     def test__git_push_no_url_success(self, git_mock):
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             step_implementer._Git__git_push(None)
@@ -797,18 +797,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
         url = 'www.xyz.com'
 
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
                 'container-image-version': {'description': '', 'value': '1.0-69442c8'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {}
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             git_mock.push.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')

--- a/tests/step_implementers/uat/test_maven_selenium_cucumber.py
+++ b/tests/step_implementers/uat/test_maven_selenium_cucumber.py
@@ -262,7 +262,7 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
 
         if assert_report_artifact:
             mvn_test_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/uat/test_maven_selenium_cucumber.py
+++ b/tests/step_implementers/uat/test_maven_selenium_cucumber.py
@@ -155,8 +155,8 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
     ):
         work_dir_path = os.path.join(test_dir.path, 'working')
 
-        cucumber_html_report_path = os.path.join(work_dir_path, 'cucumber.html')
-        cucumber_json_report_path = os.path.join(work_dir_path, 'cucumber.json')
+        cucumber_html_report_path = os.path.join(work_dir_path, 'uat', 'cucumber.html')
+        cucumber_json_report_path = os.path.join(work_dir_path, 'uat', 'cucumber.json')
 
         test_dir.write(pom_file_name, pom_content)
 
@@ -885,6 +885,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             effective_pom_path = os.path.join(
                 test_dir.path,
                 'working',
+                'uat',
                 'effective-pom.xml'
             )
             self.__run__run_step_test(

--- a/tests/step_implementers/uat/test_maven_selenium_cucumber.py
+++ b/tests/step_implementers/uat/test_maven_selenium_cucumber.py
@@ -19,14 +19,14 @@ class TestStepImplementerMavenSeleniumCucumberBase(MaveStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=MavenSeleniumCucumber,
             step_config=step_config,
             step_name='uat',
             implementer='MavenSeleniumCucumber',
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
 class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys(
@@ -34,7 +34,7 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
 ):
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_target_host_url(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             Path(pom_file_path).touch()
@@ -45,14 +45,14 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_deployed_host_urls_1(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             Path(pom_file_path).touch()
@@ -63,14 +63,14 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_success_deployed_host_urls_2(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             Path(pom_file_path).touch()
@@ -81,14 +81,14 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
     def test_MavenSeleniumCucumber_validate_required_config_or_previous_step_result_artifact_keys_fail_no_target_urls(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             pom_file_path = os.path.join(temp_dir.path, 'pom.xml')
             Path(pom_file_path).touch()
@@ -98,7 +98,7 @@ class TestStepImplementerDeployMavenSeleniumCucumber_validate_required_config_or
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             with self.assertRaisesRegex(
@@ -153,10 +153,10 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
         raise_error_on_tests=False,
         set_tls_verify_false=False
     ):
-        work_dir_path = os.path.join(test_dir.path, 'working')
+        parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
-        cucumber_html_report_path = os.path.join(work_dir_path, 'uat', 'cucumber.html')
-        cucumber_json_report_path = os.path.join(work_dir_path, 'uat', 'cucumber.json')
+        cucumber_html_report_path = os.path.join(parent_work_dir_path, 'uat', 'cucumber.html')
+        cucumber_json_report_path = os.path.join(parent_work_dir_path, 'uat', 'cucumber.json')
 
         test_dir.write(pom_file_name, pom_content)
 
@@ -189,7 +189,7 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
             uat_maven_profile = 'integration-test'
         step_implementer = self.create_step_implementer(
             step_config=step_config,
-            work_dir_path=work_dir_path,
+            parent_work_dir_path=parent_work_dir_path,
         )
 
         # mock generating settings
@@ -262,8 +262,7 @@ class TestStepImplementerMavenSeleniumCucumber_Other(TestStepImplementerMavenSel
 
         if assert_report_artifact:
             mvn_test_output_file_path = os.path.join(
-                work_dir_path,
-                'uat',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -18,14 +18,14 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Maven,
             step_config=step_config,
             step_name='unit-test',
             implementer='Maven',
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     def test_step_implementer_config_defaults(self):
@@ -65,7 +65,7 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
         raise_error_on_tests=False,
         set_tls_verify_false=False,
     ):
-        work_dir_path = os.path.join(test_dir.path, 'working')
+        parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
         test_dir.write('pom.xml', pom_content)
 
@@ -82,7 +82,7 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
             step_config['fail-on-no-tests'] = fail_on_no_tests
         step_implementer = self.create_step_implementer(
             step_config=step_config,
-            work_dir_path=work_dir_path,
+            parent_work_dir_path=parent_work_dir_path,
         )
 
         # mock generating settings
@@ -143,8 +143,7 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
 
         if assert_report_artifact:
             mvn_test_output_file_path = os.path.join(
-                work_dir_path,
-                'unit-test',
+                step_implementer.work_dir_path_step,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -366,6 +366,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             effective_pom_path = os.path.join(
                 test_dir.path,
                 'working',
+                'unit-test',
                 'effective-pom.xml'
             )
             self.__run__run_step_test(

--- a/tests/step_implementers/unit_test/test_maven_unit_test.py
+++ b/tests/step_implementers/unit_test/test_maven_unit_test.py
@@ -143,7 +143,7 @@ class TestStepImplementerMavenUnitTest(MaveStepImplementerTestCase):
 
         if assert_report_artifact:
             mvn_test_output_file_path = os.path.join(
-                step_implementer.work_dir_path_step,
+                step_implementer.work_dir_path,
                 'mvn_test_output.txt'
             )
             expected_step_result.add_artifact(

--- a/tests/step_implementers/validate_environment_configuration/test_configlint.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint.py
@@ -161,7 +161,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
 
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',
@@ -212,7 +212,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             expected_step_result.message = 'Failed config-lint scan.'
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',
@@ -252,7 +252,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             expected_step_result.message = 'Unexpected Error invoking config-lint.'
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',

--- a/tests/step_implementers/validate_environment_configuration/test_configlint.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint.py
@@ -39,7 +39,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=Configlint,
@@ -47,7 +47,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     # TESTS FOR configuration checks
@@ -68,7 +68,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_bad_yml_path(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -81,7 +81,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -99,7 +99,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_bad_rule_path(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -112,7 +112,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -130,7 +130,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_pass_prev_step(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'rules'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -141,14 +141,14 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             artifact_config = {
                 'configlint-yml-path': {'value': f'{test_file_path}'}
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -161,7 +161,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
 
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{work_dir_path}/validate-environment-configuration/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',
@@ -172,7 +172,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_fail_scan(self, configlint_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             file_to_validate_contents = 'notused'
             temp_dir.write('config-file-to-validate.yml', file_to_validate_contents.encode())
             file_to_validate_file_path = str(os.path.join(temp_dir.path, 'config-file-to-validate.yml'))
@@ -197,7 +197,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             result = step_implementer._run_step()
@@ -212,7 +212,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             expected_step_result.message = 'Failed config-lint scan.'
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{work_dir_path}/validate-environment-configuration/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',
@@ -223,7 +223,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
     @patch('sh.config_lint', create=True)
     def test_run_step_pass(self, config_lint_mock):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'file.txt'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -236,7 +236,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='Configlint',
-                work_dir_path=work_dir_path,
+                parent_work_dir_path=parent_work_dir_path,
             )
 
             config_lint_mock.side_effect = sh.ErrorReturnCode('config_lint', b'mock out', b'mock error')
@@ -252,7 +252,7 @@ class TestStepImplementerConfiglint(BaseStepImplementerTestCase):
             expected_step_result.message = 'Unexpected Error invoking config-lint.'
             expected_step_result.add_artifact(
                 name='configlint-result-set',
-                value=f'{work_dir_path}/validate-environment-configuration/configlint_results_file.txt'
+                value=f'{step_implementer.work_dir_path_step}/configlint_results_file.txt'
             )
             expected_step_result.add_artifact(
                 name='configlint-yml-path',

--- a/tests/step_implementers/validate_environment_configuration/test_configlint_from_argocd.py
+++ b/tests/step_implementers/validate_environment_configuration/test_configlint_from_argocd.py
@@ -18,7 +18,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
             step_name='',
             implementer='',
             workflow_result=None,
-            work_dir_path=''
+            parent_work_dir_path=''
     ):
         return self.create_given_step_implementer(
             step_implementer=ConfiglintFromArgocd,
@@ -26,7 +26,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
             step_name=step_name,
             implementer=implementer,
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path
+            parent_work_dir_path=parent_work_dir_path
         )
 
     # TESTS FOR configuration checks
@@ -45,7 +45,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
 
     def test_run_step_pass(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'yamlnotused'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -56,14 +56,14 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
                     'value': test_file_path
                 }
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='ConfiglintArgocd',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()
@@ -82,7 +82,7 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
 
     def test_run_step_fail_missing_path_file_from_deploy(self):
         with TempDirectory() as temp_dir:
-            work_dir_path = os.path.join(temp_dir.path, 'working')
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             test_file_name = 'yamlnotused'
             test_file_path = os.path.join(temp_dir.path, test_file_name)
             temp_dir.write(test_file_path, b'ignored')
@@ -93,14 +93,14 @@ class TestStepImplementerConfiglintFromArgocd(BaseStepImplementerTestCase):
                     'value': f'{test_file_path}.bad'
                 }
             }
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='validate-environment-configuration',
                 implementer='ConfiglintArgocd',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             result = step_implementer._run_step()

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -53,7 +53,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             'new-param-name': 'bar42'
         }
 
-        work_dir_path = os.path.join(test_dir.path, 'working')
+        parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
         workflow_result = WorkflowResult()
 
@@ -80,7 +80,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             value='https://awesome-app.prod.ploigos.xyz'
         )
         workflow_result.add_step_result(step_result=step_result_deploy_prod)
-        pickle_filename = os.path.join(work_dir_path, 'step-runner-results.pkl')
+        pickle_filename = os.path.join(parent_work_dir_path, 'step-runner-results.pkl')
         workflow_result.write_to_pickle_file(pickle_filename=pickle_filename)
 
         return self.create_given_step_implementer(
@@ -89,7 +89,7 @@ class TestStepImplementer(BaseStepImplementerTestCase):
             step_name='foo',
             implementer='FooStepImplementer',
             workflow_result=workflow_result,
-            work_dir_path=work_dir_path,
+            parent_work_dir_path=parent_work_dir_path,
             environment=environment
         )
 
@@ -659,7 +659,7 @@ class TestStepImplementer_other(TestStepImplementer):
 
         step = WriteConfigAsResultsStepImplementer(
             workflow_result=None,
-            work_dir_path='',
+            parent_work_dir_path='',
             config=sub_step
         )
 
@@ -685,7 +685,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step
             )
 
@@ -712,7 +712,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step
             )
 
@@ -730,14 +730,14 @@ class TestStepImplementer_other(TestStepImplementer):
         }
 
         with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             step = self.create_given_step_implementer(
                 step_implementer=FooStepImplementer,
                 step_config=step_config,
                 step_name='foo',
                 implementer='FooStepImplementer',
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             self.assertEqual(step.get_config_value('test'), 'hello world')
@@ -771,7 +771,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step,
                 environment='SAMPLE-ENV-1'
             )
@@ -812,7 +812,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step,
                 environment='SAMPLE-ENV-1'
             )
@@ -843,7 +843,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FailStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step
             )
             result = step.run_step()
@@ -867,7 +867,7 @@ class TestStepImplementer_other(TestStepImplementer):
             working_dir_path = os.path.join(test_dir.path, 'step-runner-working')
             step = FooStepImplementer(
                 workflow_result=WorkflowResult(),
-                work_dir_path=working_dir_path,
+                parent_work_dir_path=working_dir_path,
                 config=sub_step
             )
 
@@ -886,7 +886,7 @@ class TestStepImplementer_get_value(TestStepImplementer):
         }
 
         with TempDirectory() as test_dir:
-            work_dir_path = os.path.join(test_dir.path, 'working')
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
 
             artifact_config = {
                 'fake-previous-step-artifact': {
@@ -895,7 +895,7 @@ class TestStepImplementer_get_value(TestStepImplementer):
                 },
             }
 
-            workflow_result = self.setup_previous_result(work_dir_path, artifact_config)
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step = self.create_given_step_implementer(
                 step_implementer=FooStepImplementer,
@@ -903,7 +903,7 @@ class TestStepImplementer_get_value(TestStepImplementer):
                 step_name='foo',
                 implementer='FooStepImplementer',
                 workflow_result=workflow_result,
-                work_dir_path=work_dir_path
+                parent_work_dir_path=parent_work_dir_path
             )
 
             self.assertEqual(step.get_value('test'), 'hello world')
@@ -984,7 +984,7 @@ class TestStepImplementer_validate_required_config_or_previous_step_result_artif
                 step_config=step_config,
                 step_name='foo',
                 implementer='RequiredStepConfigMultipleOptionsStepImplementer',
-                work_dir_path=test_dir.path
+                parent_work_dir_path=test_dir.path
             )
 
             with self.assertRaisesRegex(
@@ -1005,7 +1005,7 @@ class TestStepImplementer_validate_required_config_or_previous_step_result_artif
                 step_config=step_config,
                 step_name='foo',
                 implementer='RequiredStepConfigMultipleOptionsStepImplementer',
-                work_dir_path=test_dir.path
+                parent_work_dir_path=test_dir.path
             )
 
             step._validate_required_config_or_previous_step_result_artifact_keys()
@@ -1021,7 +1021,7 @@ class TestStepImplementer_validate_required_config_or_previous_step_result_artif
                 step_config=step_config,
                 step_name='foo',
                 implementer='RequiredStepConfigMultipleOptionsStepImplementer',
-                work_dir_path=test_dir.path
+                parent_work_dir_path=test_dir.path
             )
 
             step._validate_required_config_or_previous_step_result_artifact_keys()


### PR DESCRIPTION
# issue

some of the StepImplmeneter instances were rferecing the `work_dir_path` property instead of `work_dir_path_step` which meant they were accidently rm-rfing the entiring working dir for previous steps, which was messing up the reproting.

# fix

rename `StepImplementer#__init__(work_dir_path)` parameter to `parent_work_dir_path` and make it private. Then remove the public `StepImpelmenter#work_dir_path` property and refacotr everything to properly use the `StepImplementer#work_dir_path_step`. Then for good mesure, rename `StepImplementer#work_dir_path_step` to `StepImplementer#work_dir_path` since now that is the only work dir path the StepImplementer instances can access and its more clear.

# integration test

* https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applications/job/reference-quarkus-mvn_jenkins_workflow-standard/view/change-requests/job/PR-36/5/console