### PR TITLE
Ensure we use "application/octet-stream" as Content-Type for file upload.

### DIFF
--- a/src/ploigos_step_runner/utils/file.py
+++ b/src/ploigos_step_runner/utils/file.py
@@ -267,11 +267,17 @@ def upload_file(file_path, destination_uri, username=None, password=None): # pyl
             opener = urllib.request.build_opener()
 
         with open(file_path, 'rb') as file:
-            request = urllib.request.Request(url=destination_uri, data=file.read(), method='PUT')
+            request = urllib.request.Request(url=destination_uri, data=file.read(), method='PUT',
+                                             headers={'Content-Type': 'application/octet-stream'})
 
             try:
                 result = opener.open(request)
-                upload_result = str(result.read(), encoding='utf8')
+                response_reason = result.reason
+                response_body = str(result.read(), encoding='utf8')
+                response_code = result.status
+                upload_result = f"status={response_code}, " \
+                                f"reason={response_reason}, " \
+                                f"body={response_body}"
             except urllib.error.HTTPError as error:
                 raise RuntimeError(
                     f"Error uploading file ({file_path}) to destination ({destination_uri})"

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -183,6 +183,8 @@ class TestUploadFile(BaseTestCase):
         def http_response_side_effect(request):
             mock_response = Mock()
             mock_response.read.return_value = read_return
+            mock_response.status = '201'
+            mock_response.reason = 'Created'
             return mock_response
 
         return http_response_side_effect
@@ -278,7 +280,7 @@ class TestUploadFile(BaseTestCase):
             file_path=sample_file_path,
             destination_uri="http://ploigos.com/test/foo42"
         )
-        self.assertEqual('hello world 42', actual_result)
+        self.assertEqual('status=201, reason=Created, body=hello world 42', actual_result)
 
     @patch.object(
          urllib.request.OpenerDirector,
@@ -297,7 +299,7 @@ class TestUploadFile(BaseTestCase):
             file_path=sample_file_path,
             destination_uri="https://ploigos.com/test/foo42"
         )
-        self.assertEqual('hello world 42', actual_result)
+        self.assertEqual('status=201, reason=Created, body=hello world 42', actual_result)
 
     @patch.object(
          urllib.request.OpenerDirector,
@@ -319,7 +321,7 @@ class TestUploadFile(BaseTestCase):
             username='test_user',
             password='pass123'
         )
-        self.assertEqual('hello world 42', actual_result)
+        self.assertEqual('status=201, reason=Created, body=hello world 42', actual_result)
 
         pass_manager_mock().add_password.assert_called_once_with(
             None,


### PR DESCRIPTION
We should pass the header `Content-Type: application/octet-stream` when uploading arbitrary binary data such as the container signature.

Nexus, at least, will fail to process the uploaded file if we omit this header; I assume Nexus considers the incoming body as text instead of a stream of bytes. Unhelpfully it will return `500 Internal Server Error` but the failure is only visible in Nexus logs when logging is set to `DEBUG`.

Nexus also doesn't return a body on successful create. This causes the `upload_result` to be empty, which makes the step artifact value for `container-image-signature-upload-results` empty, which in turn causes an exception. This change always creates a valid return value - assuming the upload completes successfully - that describes the HTTP status code, the reason, and any body (which may be empty).