### PR TITLE
Feature/rekor refactor

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_evidence/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/generate_evidence/__init__.py
@@ -3,3 +3,5 @@
 
 from ploigos_step_runner.step_implementers.generate_evidence.generate_evidence import \
     GenerateEvidence
+from ploigos_step_runner.step_implementers.generate_evidence.rekor_sign_evidence import \
+    RekorSignEvidence


### PR DESCRIPTION
Fixing missing import statement in generate_evidence step for rekor.

Think this may have accidentally been deleted during a rebase.