### PR TITLE
deploy/argocd better errors

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd.py
@@ -864,9 +864,7 @@ class ArgoCD(StepImplementer):
                 argocd_api,
                 f'--username={username}',
                 f'--password={password}',
-                insecure_flag,
-                _out=sys.stdout,
-                _err=sys.stderr
+                insecure_flag
             )
         except sh.ErrorReturnCode as error:
             raise StepRunnerException(f"Error logging in to ArgoCD: {error}") from error


### PR DESCRIPTION
# purpose

better argo error handling

# examples

## old
```

    --------------------------------------------------------------------------------
                                    Results - deploy                                
    --------------------------------------------------------------------------------
        Environment
            DEV

        Step
            deploy

        Sub Step
            ArgoCD

        Sub Step Implementer
            ArgoCD

        Success
            False

        Message
            Error deploying to environment (DEV): Error logging in to ArgoCD: 

              RAN: /usr/bin/argocd login https://argocd-server-argocd.apps.tssc.rht-set.com --username=admin --password=************************ --insecure

              STDOUT:


              STDERR:


        Artifacts
            [
                {
                    "name": "argocd-app-name",
                    "value": "mvn-jenkins-min-fruit-feature-argo-better-errors-dev",
                    "description": ""
                },
                {
                    "name": "config-repo-git-tag",
                    "value": "1.0.2-feature_argo-better-errors+505efae.DEV",
                    "description": ""
                }
            ]
```

## new

```
    --------------------------------------------------------------------------------
                                    Results - deploy                                
    --------------------------------------------------------------------------------
        Environment
            DEV

        Step
            deploy

        Sub Step
            ArgoCD

        Sub Step Implementer
            ArgoCD

        Success
            False

        Message
            Error deploying to environment (DEV): Error logging in to ArgoCD: 

              RAN: /usr/bin/argocd login https://argocd-server-argocd.apps.tssc.rht-set.com --username=admin --password=********************************** --insecure

              STDOUT:


              STDERR:
            time="2021-07-16T18:28:46Z" level=fatal msg="dial tcp: address tcp///argocd-server-argocd.apps.tssc.rht-set.com: unknown port"


        Artifacts
            [
                {
                    "name": "argocd-app-name",
                    "value": "mvn-jenkins-min-fruit-feature-argo-better-errors-dev",
                    "description": ""
                },
                {
                    "name": "config-repo-git-tag",
                    "value": "1.0.2-feature_argo-better-errors+df1f69b.DEV",
                    "description": ""
                }
            ]
```