### PR TITLE
BREAKING (possibly): removes defaulting storage driver to vfs for podman/buildah/skopeo operations 

### DIFF
--- a/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
@@ -152,12 +152,7 @@ class Buildah(StepImplementer):
             )
 
             # perform build
-            #
-            # NOTE: using --storage-driver=vfs so that container does not need escalated privileges
-            #       vfs is less efficient then fuse (which would require host mounts),
-            #       but such is the price we pay for security.
             sh.buildah.bud(  # pylint: disable=no-member
-                '--storage-driver=vfs',
                 '--format=' + self.get_value('format'),
                 '--tls-verify=' + str(tls_verify).lower(),
                 '--layers', '-f', image_spec_file,
@@ -185,14 +180,9 @@ class Buildah(StepImplementer):
             # Check to see if the tar docker-archive file already exists
             #   this needs to be run as buildah does not support overwritting
             #   existing files.
-            #
-            # NOTE: using --storage-driver=vfs so that container does not need escalated privileges
-            #       vfs is less efficient then fuse (which would require host mounts),
-            #       but such is the price we pay for security.
             if os.path.exists(image_tar_path):
                 os.remove(image_tar_path)
             sh.buildah.push(  # pylint: disable=no-member
-                '--storage-driver=vfs',
                 tag,
                 "docker-archive:" + image_tar_path,
                 _out=sys.stdout,

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -104,7 +104,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
 
 
             buildah_mock.bud.assert_called_once_with(
-                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers', '-f', 'Containerfile',
@@ -117,7 +116,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
 
             buildah_mock.push.assert_called_once_with(
-                '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
                 f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,
@@ -166,7 +164,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
 
             buildah_mock.bud.assert_called_once_with(
-                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers', '-f', 'Containerfile',
@@ -179,7 +176,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
 
             buildah_mock.push.assert_called_once_with(
-                '--storage-driver=vfs',
                 'localhost/app-name/service-name:latest',
                 f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-latest.tar',
                 _out=sys.stdout,
@@ -236,7 +232,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
 
 
             buildah_mock.bud.assert_called_once_with(
-                '--storage-driver=vfs',
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers', '-f', 'Containerfile',
@@ -249,7 +244,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             )
 
             buildah_mock.push.assert_called_once_with(
-                '--storage-driver=vfs',
                 'localhost/app-name/service-name:1.0-123abc',
                 f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
                 _out=sys.stdout,


### PR DESCRIPTION
# purpose

removes defaulting storage driver to vfs for podman/buildah/skopeo operations and instead assumes the context psr is running in has set the storage driver appropriately based on avialble permissions. doing this because 'sometime soon' overlay should work with rootless pods once kernerls / kube distributions catch up

# related / dependent on
* https://github.com/ploigos/ploigos-containers/pull/80

# integration testing
## jenkins
 - [x] [minimum](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/)
  - [x] [typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/) 
  - [x] [everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-26/3/)