### PR TITLE
get latest result artifact value not first

### DIFF
--- a/src/ploigos_step_runner/results/workflow_result.py
+++ b/src/ploigos_step_runner/results/workflow_result.py
@@ -60,7 +60,7 @@ class WorkflowResult:
         """
 
         value = None
-        for step_result in self.workflow_list:
+        for step_result in reversed(self.workflow_list):
             if ( \
                 (not step_name or step_result.step_name == step_name) and \
                 (not sub_step_name or step_result.sub_step_name == sub_step_name) and \

--- a/tests/results/test_workflow_result.py
+++ b/tests/results/test_workflow_result.py
@@ -23,7 +23,7 @@ def setup_test():
     step_result1.add_evidence('evidence3', 'value3')
     step_result1.add_evidence('evidence4', False)
     step_result1.add_evidence('same-evidence-all-env-and-no-env', 'result1')
-    
+
 
     step_result2 = StepResult('step2', 'sub2', 'implementer2')
     step_result2.add_artifact('artifact1', True)
@@ -103,7 +103,7 @@ class TestStepWorkflowResultTest(BaseTestCase):
     def test_get_artifact_value_without_step(self):
         wfr = setup_test()
 
-        expected_artifact = 'value1'
+        expected_artifact = True
         self.assertEqual(
             expected_artifact,
             wfr.get_artifact_value(artifact='artifact1')
@@ -237,7 +237,7 @@ class TestStepWorkflowResultTest(BaseTestCase):
             wfr.get_artifact_value(
                 artifact='same-artifact-all-env-and-no-env'
             ),
-            'result1'
+            'result4-test-env'
         )
 
         self.assertEqual(
@@ -289,7 +289,7 @@ class TestStepWorkflowResultTest(BaseTestCase):
             wfr.get_artifact_value(
                 artifact='same-artifact-diff-env'
             ),
-            'value-dev-env'
+            'value-test-env'
         )
 
         self.assertEqual(


### PR DESCRIPTION
# purpose

currently when calling `StepImplementer#get_value` if multiple steps created an artifact with the same name, assuming you dont specify a step name, sub step name, and/or environment, then you will get the first instance of that artifact. Though, it makes more sense to return the last.

# use case

if the build step sets a `container-image-tag` artifact with a local container storage tag, and then the push container image step sets the same artifact with a remote tag, in the deploy step, intitivly you want to pull the tag of the last step that set that `container-image-tag` artifact.