### PR TITLE
use local container storage refactor

### DIFF
--- a/src/ploigos_step_runner/results/workflow_result.py
+++ b/src/ploigos_step_runner/results/workflow_result.py
@@ -35,8 +35,8 @@ class WorkflowResult:
     ): # pylint: disable=too-many-boolean-expressions
         """Search for an artifact.
 
-        If step_name, sub_step_name, or environment are provided ensure the artifact comes
-        from the first
+        If step_name, sub_step_name, or environment are not provided ensure the artifact comes
+        from the last step that returned that artifact.
 
         1.  if step_name is provided, look for the artifact in the step
         2.  elif step_name and sub_step_name is provided, look for the artifact in the step/sub_step

--- a/src/ploigos_step_runner/step_implementers/container_image_static_compliance_scan/openscap.py
+++ b/src/ploigos_step_runner/step_implementers/container_image_static_compliance_scan/openscap.py
@@ -14,16 +14,15 @@ Could come from:
 
  Configuration Key             | Required? | Default | Description
 -------------------------------|-----------|---------|-----------
-`image-tar-file`               | Yes       |         | Path to container image tar file to scan
+`container-image-tag`          | Yes       |         | Container image tag to scan.
 `oscap-input-definitions-uri`  | Yes       |         | URI to the OpenSCAP definitions file \
                                                        to do the evaluation with. \
-                                                       Must use protocol file://|http://|https://.
-                               |           |         | Must have file extension .xml|.bz2.
-`oscap-profile`                | Yes       |         | OpenSCAP profile to evaluate.
+                                                       Must use protocol file://|http://|https://. \
+                                                       Must have file extension .xml|.bz2.
+`oscap-profile`                | No        |         | OpenSCAP profile to evaluate.
 `oscap-tailoring-uri`          | No        |         | URI to OpenSCAP tailoring file \
                                                        to do the evaluation with. \
-                                                       Must use protocol \
-                                                       file://|http://|https://. \
+                                                       Must use protocol file://|http://|https://. \
                                                        Must have file extension .xml|.bz2.
 `oscap-fetch-remote-resources` | No        | True    | For Source DataStream and XCCDF files \
                                                        that have remote references fetch them if \
@@ -34,6 +33,12 @@ Could come from:
                                                        remote resources and this is not True. \
                                                        For disconnected environments the remote \
                                                        internal mirror.
+`[container-image-pull-repository-type, container-image-repository-type]` \
+                               | Yes       | 'containers-storage:' \
+                                                     | \
+                                           Container repository type for the pull image source. \
+                                           See https://github.com/containers/skopeo for valid \
+                                           options.
 
 Result Artifacts
 ----------------

--- a/src/ploigos_step_runner/step_implementers/container_image_static_vulnerability_scan/openscap.py
+++ b/src/ploigos_step_runner/step_implementers/container_image_static_vulnerability_scan/openscap.py
@@ -13,17 +13,16 @@ Could come from:
   * previous step results
 
  Configuration Key             | Required? | Default | Description
--------------------------------|-----------|---------|------------
-`image-tar-file`               | Yes       |         | Path to container image tar file to scan
+-------------------------------|-----------|---------|-----------
+`container-image-tag`          | Yes       |         | Container image tag to scan.
 `oscap-input-definitions-uri`  | Yes       |         | URI to the OpenSCAP definitions file \
                                                        to do the evaluation with. \
-                                                       Must use protocol file://|http://|https://.
-                               |           |         | Must have file extension .xml|.bz2.
+                                                       Must use protocol file://|http://|https://. \
+                                                       Must have file extension .xml|.bz2.
 `oscap-profile`                | No        |         | OpenSCAP profile to evaluate.
 `oscap-tailoring-uri`          | No        |         | URI to OpenSCAP tailoring file \
                                                        to do the evaluation with. \
-                                                       Must use protocol \
-                                                       file://|http://|https://. \
+                                                       Must use protocol file://|http://|https://. \
                                                        Must have file extension .xml|.bz2.
 `oscap-fetch-remote-resources` | No        | True    | For Source DataStream and XCCDF files \
                                                        that have remote references fetch them if \
@@ -34,6 +33,12 @@ Could come from:
                                                        remote resources and this is not True. \
                                                        For disconnected environments the remote \
                                                        internal mirror.
+`[container-image-pull-repository-type, container-image-repository-type]` \
+                               | Yes       | 'containers-storage:' \
+                                                     | \
+                                           Container repository type for the pull image source. \
+                                           See https://github.com/containers/skopeo for valid \
+                                           options.
 
 Result Artifacts
 ----------------

--- a/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/buildah.py
@@ -9,41 +9,64 @@ Could come from:
   * runtime configuration
   * previous step results
 
-Configuration Key | Required? | Default | Description
-------------------|-----------|---------|-----------
-`imagespecfile`   | True      | `'Containerfile'` \
-                                        | File defining the container image
-`context`         | True      | `'.'`   | Context to build the container image in
-`tls-verify`      | True      | `True`  | Whether to verify TLS when pulling parent images
-`format`          | True      | `'oci'` | format of the built image's manifest and metadata
+Configuration Key  | Required? | Default | Description
+-------------------|-----------|---------|-----------
+`imagespecfile`    | True      | `'Containerfile'` \
+                                         | File defining the container image
+`context`          | True      | `'.'`   | Context to build the container image in
+`tls-verify`       | True      | `True`  | Whether to verify TLS when pulling parent images
+`format`           | True      | `'oci'` | format of the built image's manifest and metadata
 `containers-config-auth-file` \
-                  | True      | `'~/.buildah-auth.json'` \
-                                        | Path to the container registry authentication \
-                                          file to use for container registry authentication.
+                   | False     |         | Path to the container registry authentication \
+                                           file to use for container registry authentication. \
+                                           If one is not provided one will be created in the \
+                                           working directory.
 `container-image-version` \
-                  | True      |         | Version to use when building the container image
+                   | True      |         | Version to use when building the container image
+`organization`     | True      |         | Used in built container image tag
+`application_name` | True      |         | Used in built container image tag
+`service_name`     | True      |         | Used in built container image tag
+`container-registries` \
+                   | False     |         | Hash of container registries to authenticate with.
 
 Result Artifacts
 ----------------
 Results artifacts output by this step.
 
-Result Artifact Key | Description
---------------------------|------------
-`container-image-version` | Container version to tag built image with
-`image-tar-file`          | Path to the built container image as a tar file
-"""
+Result Artifact Key            | Description
+-------------------------------|------------
+`container-image-registry-uri` | Registry URI poriton of the container image tag \
+                                 of the built container image.
+`container-image-registry-organization` \
+                               | Organization portion of the container image tag \
+                                 of the built container image.
+`container-image-repository`   | Repository portion of the container image tag \
+                                 of the built container image.
+`container-image-name`         | Another way to reference the \
+                                 repository portion of the container image tag \
+                                 of the built container image.
+`container-image-version`      | Version portion of the container image tag \
+                                 of the built container image.
+`container-image-tag`          | Full container image tag of the built container, \
+                                 including the registry URI. <br/> \
+                                 Takes the form of: \
+                                    `container-image-registry-organization/container-image-repository:container-image-version`
+`container-image-short-tag`    | Short container image tag of the built container image, \
+                                 excluding the registry URI. <br/> \
+                                 Takes the form of: \
+                                    `container-image-registry-uri/container-image-registry-organization/container-image-repository:container-image-version`
+
+""" # pylint: disable=line-too-long
+
 import os
 import sys
-from pathlib import Path
+from distutils import util
 
 import sh
 from ploigos_step_runner import StepImplementer, StepResult
 from ploigos_step_runner.utils.containers import container_registries_login
 
 DEFAULT_CONFIG = {
-    # Path to the container registry authentication file to read and write to/from.
-    'containers-config-auth-file': os.path.join(Path.home(), '.buildah-auth.json'),
-
     # Image specification file name
     'imagespecfile': 'Containerfile',
 
@@ -58,11 +81,11 @@ DEFAULT_CONFIG = {
 }
 
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
-    'containers-config-auth-file',
     'imagespecfile',
     'context',
     'tls-verify',
     'format',
+    'organization',
     'service-name',
     'application-name'
 ]
@@ -103,6 +126,29 @@ class Buildah(StepImplementer):
         """
         return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
 
+    def _validate_required_config_or_previous_step_result_artifact_keys(self):
+        """Validates that the required configuration keys or previous step result artifacts
+        are set and have valid values.
+
+        Validates that:
+        * required configuration is given
+        * given 'imagespecfile' exists
+
+        Raises
+        ------
+        AssertionError
+            If step configuration or previous step result artifacts have invalid required values
+        """
+        super()._validate_required_config_or_previous_step_result_artifact_keys()
+
+        # if pom-file has value verify file exists
+        # If it doesn't have value and is required function will have already failed
+        image_spec_file = self.get_value('imagespecfile')
+        context = self.get_value('context')
+        image_spec_file_full_path = os.path.join(context, image_spec_file)
+        assert os.path.exists(image_spec_file_full_path), \
+            f'Given imagespecfile ({image_spec_file}) does not exist in given context ({context}).'
+
     def _run_step(self):
         """Runs the step implemented by this StepImplementer.
 
@@ -113,38 +159,33 @@ class Buildah(StepImplementer):
         """
         step_result = StepResult.from_step_implementer(self)
 
-        context = self.get_value('context')
+        # get config
         image_spec_file = self.get_value('imagespecfile')
-        image_spec_file_location = os.path.join(context, image_spec_file)
-        application_name = self.get_value('application-name')
-        service_name = self.get_value('service-name')
         tls_verify = self.get_value('tls-verify')
+        if isinstance(tls_verify, str):
+            tls_verify = bool(util.strtobool(tls_verify))
 
-        if not os.path.exists(image_spec_file_location):
-            step_result.success = False
-            step_result.message = 'Image specification file does not exist in location: ' \
-                f'{image_spec_file_location}'
-            return step_result
-
-        image_tag_version = self.get_value('container-image-version')
-        if image_tag_version is None:
-            image_tag_version = 'latest'
+        # create local build tag
+        image_version = self.get_value('container-image-version')
+        if image_version is None:
+            image_version = 'latest'
             print('No image tag version found in metadata. Using latest')
-
-        destination = "localhost/{application_name}/{service_name}".format(
-            application_name=application_name,
-            service_name=service_name
-        )
-        tag = "{destination}:{version}".format(
-            destination=destination,
-            version=image_tag_version
-        )
+        image_registry_uri = 'localhost'
+        image_registry_organization = self.get_value('organization')
+        image_repository = f"{self.get_value('application-name')}-{self.get_value('service-name')}"
+        short_tag = f"{image_registry_organization}/{image_repository}:{image_version}"
+        build_tag = f"{image_registry_uri}/{short_tag}"
 
         try:
             # login to any provider container registries
             # NOTE: important to specify the auth file because depending on the context this is
             #       being run in python process may not have permissions to default location
             containers_config_auth_file = self.get_value('containers-config-auth-file')
+            if not containers_config_auth_file:
+                containers_config_auth_file = os.path.join(
+                    self.work_dir_path,
+                    'container-auth.json'
+                )
             container_registries_login(
                 registries=self.get_value('container-registries'),
                 containers_config_auth_file=containers_config_auth_file,
@@ -156,48 +197,61 @@ class Buildah(StepImplementer):
                 '--format=' + self.get_value('format'),
                 '--tls-verify=' + str(tls_verify).lower(),
                 '--layers', '-f', image_spec_file,
-                '-t', tag,
+                '-t', build_tag,
                 '--authfile', containers_config_auth_file,
-                context,
+                self.get_value('context'),
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
             )
 
-            step_result.add_artifact(
-                name='container-image-version',
-                value=tag
-            )
         except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
             step_result.success = False
             step_result.message = 'Issue invoking buildah bud with given image ' \
                 f'specification file ({image_spec_file}): {error}'
             return step_result
 
-        image_tar_file = f'image-{application_name}-{service_name}-{image_tag_version}.tar'
-        image_tar_path = os.path.join(self.work_dir_path, image_tar_file)
-        try:
-            # Check to see if the tar docker-archive file already exists
-            #   this needs to be run as buildah does not support overwritting
-            #   existing files.
-            if os.path.exists(image_tar_path):
-                os.remove(image_tar_path)
-            sh.buildah.push(  # pylint: disable=no-member
-                tag,
-                "docker-archive:" + image_tar_path,
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-
-            step_result.add_artifact(
-                name='image-tar-file',
-                value=image_tar_path
-            )
-        except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
-            step_result.success = False
-            step_result.message = f'Issue invoking buildah push to tar file ' \
-                f'({image_tar_path}): {error}'
-            return step_result
+        # add artifacts
+        step_result.add_artifact(
+            name='container-image-registry-uri',
+            value=image_registry_uri,
+            description='Registry URI poriton of the container image tag' \
+                ' of the built container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-registry-organization',
+            value=image_registry_organization,
+            description='Organization portion of the container image tag' \
+                ' of the built container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-repository',
+            value=image_repository,
+            description='Repository portion of the container image tag' \
+                ' of the built container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-name',
+            value=image_repository,
+            description='Another way to reference the' \
+                ' repository portion of the container image tag of the built container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-version',
+            value=image_version,
+            description='Version portion of the container image tag of the built container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-tag',
+            value=build_tag,
+            description='Full container image tag of the built container,' \
+                ' including the registry URI.'
+        )
+        step_result.add_artifact(
+            name='container-image-short-tag',
+            value=short_tag,
+            description='Short container image tag of the built container image,' \
+                ' excluding the registry URI.'
+        )
 
         return step_result

--- a/src/ploigos_step_runner/step_implementers/deploy/argocd.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd.py
@@ -265,7 +265,7 @@ class ArgoCD(StepImplementer):
                 repo_branch=deployment_config_repo_branch,
                 git_email=self.get_value('git-email'),
                 git_name=self.get_value('git-name'),
-	          username = self.get_value('git-username'),
+                username = self.get_value('git-username'),
                 password = self.get_value('git-password')
             )
 

--- a/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
@@ -9,66 +9,97 @@ Could come from:
   * runtime configuration
   * previous step results
 
-Configuration Key | Required? | Default  | Description
-------------------|-----------|----------|-----------
-`destination-url` | Yes       |          | Container image repository destination to push image \
-                                           to. o not include the `docker://` prefix as it will \
-                                           automatically be applied
-`src-tls-verify`  | Yes       | `'true'` | Whether to very TLS for source of image
-`dest-tls-verify` | Yes       | `'true'` | Whether to verify TLS for destination of image
-`containers-config-auth-file` | Yes | `'~/.container-image-repo-auth.json'` | \
-                                           Path to the container registry authentication file \
-                                           to use for container registry authentication.
-`container-image-version`     | Yes |    | Tag to push container image with
-`image-tar-file`  | Yes       |          | Local tar file of container image to push
+Configuration Key  | Required? | Default | Description
+-------------------|-----------|---------|-----------
+`container-image-version` \
+                   | Yes       |         | Version to use when pushing the container image
+`organization`     | Yes       |         | Used in creating the container image push tag
+`application_name` | Yes       |         | Used in creating the container image push tag
+`service_name`     | Yes       |         | Used in creating the container image push tag
+`destination-url`  | Yes       |         | Container image repository destination to push image \
+                                           to. <br/> \
+                                           Should not include the repository type.
+`[source-tls,verify, src-tls-verify]` \
+                   | Yes       | `True`  | Whether to verify TLS when pulling source image.
+`dest-tls-verify`  | Yes       | `True`  | Whether to verify TLS when pushing destination image.
+`[container-image-pull-tag, container-image-tag]` \
+                   | Yes       |         | Container image tag of image to push to \
+                                           `destination-url`.
+`[container-image-pull-repository-type, container-image-repository-type]` \
+                   | Yes       | 'containers-storage:' \
+                                         | Container repository type for the pull image source. \
+                                           See https://github.com/containers/skopeo for valid \
+                                           options.
+`[container-image-push-repository-type, container-image-repository-type]` \
+                   | Yes       | 'docker://' \
+                                         | Container repository type for the push image source. \
+                                           See https://github.com/containers/skopeo for valid \
+                                           options.
+`containers-config-auth-file` \
+                   | No        |         | Path to the container registry authentication file \
+                                           to use for container registry authentication. \
+                                           If one is not provided one will be created in the \
+                                           working directory.
+`container-registries` \
+                   | False     |         | Hash of container registries to authenticate with.
+
 
 Result Artifacts
 ----------------
 Results artifacts output by this step.
 
-Result Artifact Key                     | Description
-----------------------------------------|------------
-`container-image-registry-uri`          | URI to the image registry service.
-`container-image-registry-organization` | Organization in the image registry to push the image to.
-`container-image-repository`            | Repository in the Organization in the image registry to \
-                                          push the image to.
-`container-image-name`                  | Name of the image to push to the Image Repository. \
-                                          This is the same value as `container-image-repository` as\
-                                          these are always the same, but people refer to them \
-                                          differently in different cases, so providing both.
-`container-image-version`               | Version of the image to push.
-`container-image-tag`                   | Tag container image was pushed with. <br/>\
-                                          Takes the form of: \
-                                            "`container-image-registry-uri`\
-                                                /`container-image-registry-organization`\
-                                                /`container-image-repository`\
-                                                :`container-image-version`"
-"""
+Result Artifact Key            | Description
+-------------------------------|------------
+`container-image-registry-uri` | Registry URI poriton of the container image tag \
+                                 of the pushed container image.
+`container-image-registry-organization` \
+                               | Organization portion of the container image tag \
+                                 of the pushed container image.
+`container-image-repository`   | Repository portion of the container image tag \
+                                 of the pushed container image.
+`container-image-name`         | Another way to reference the \
+                                 repository portion of the container image tag \
+                                 of the pushed container image.
+`container-image-version`      | Version portion of the container image tag \
+                                 of the pushed container image.
+`container-image-tag`          | Full container image tag of the pushed container, \
+                                 including the registry URI. <br/> \
+                                 Takes the form of: \
+                                    `container-image-registry-organization/container-image-repository:container-image-version`
+`container-image-short-tag`    | Short container image tag of the pushed container image, \
+                                 excluding the registry URI. <br/> \
+                                 Takes the form of: \
+                                    `container-image-registry-uri/container-image-registry-organization/container-image-repository:container-image-version`
+
+""" # pylint: disable=line-too-long
+
 import os
 import sys
 from distutils import util
-from pathlib import Path
 
 import sh
 from ploigos_step_runner import StepImplementer, StepResult
 from ploigos_step_runner.utils.containers import container_registries_login
 
 DEFAULT_CONFIG = {
-    'src-tls-verify': 'true',
-    'dest-tls-verify': 'true',
-    'containers-config-auth-file': os.path.join(Path.home(), '.container-image-repo-auth.json')
+    'src-tls-verify': True,
+    'dest-tls-verify': True,
+    'container-image-pull-repository-type': 'containers-storage:',
+    'container-image-push-repository-type': 'docker://'
 }
 
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
-    'containers-config-auth-file',
     'destination-url',
-    'src-tls-verify',
+    ['source-tls,verify', 'src-tls-verify'],
     'dest-tls-verify',
     'service-name',
     'application-name',
     'organization',
-    'container-image-version',
-    'image-tar-file'
+
+    # being flexible for different use cases of proceeding steps
+    ['container-image-pull-tag', 'container-image-tag'],
+    ['container-image-pull-repository-type', 'container-image-repository-type'],
+    ['container-image-push-repository-type', 'container-image-repository-type']
 ]
 
 class Skopeo(StepImplementer):
@@ -117,55 +148,108 @@ class Skopeo(StepImplementer):
         """
         step_result = StepResult.from_step_implementer(self)
 
-        image_version = self.get_value('container-image-version').lower()
-        application_name = self.get_value('application-name')
-        service_name = self.get_value('service-name')
-        organization = self.get_value('organization')
-        image_tar_file = self.get_value('image-tar-file')
-        destination_url = self.get_value('destination-url')
+        # get config
+        image_pull_tag = self.get_value(['container-image-pull-tag', 'container-image-tag'])
+        pull_repository_type = self.get_value([
+            'container-image-pull-repository-type',
+            'container-image-repository-type'
+        ])
+        push_repository_type = self.get_value([
+            'container-image-push-repository-type',
+            'container-image-repository-type'
+        ])
         dest_tls_verify = self.get_value('dest-tls-verify')
+        if isinstance(dest_tls_verify, str):
+            dest_tls_verify = bool(util.strtobool(dest_tls_verify))
+        source_tls_verify = self.get_value(['source-tls-verify', 'src-tls-verify'])
+        if isinstance(source_tls_verify, str):
+            source_tls_verify = bool(util.strtobool(source_tls_verify))
 
-        image_registry_uri = destination_url
-        image_registry_organization = organization
-        image_repository = f"{application_name}-{service_name}"
-        image_tag = f"{image_registry_uri}/{image_registry_organization}" \
-                    f"/{image_repository}:{image_version}"
+        # create push tag
+        image_version = self.get_value('container-image-version')
+        if image_version is None:
+            image_version = 'latest'
+            print('No image tag version found in metadata. Using latest')
+        image_version = image_version.lower()
+        image_registry_uri = self.get_value('destination-url')
+        image_registry_organization = self.get_value('organization')
+        image_repository = f"{self.get_value('application-name')}-{self.get_value('service-name')}"
+        image_push_short_tag = f"{image_registry_organization}/{image_repository}:{image_version}"
+        image_push_tag = f"{image_registry_uri}/{image_push_short_tag}"
 
         try:
             # login to any provider container registries
             # NOTE: important to specify the auth file because depending on the context this is
             #       being run in python process may not have permissions to default location
             containers_config_auth_file = self.get_value('containers-config-auth-file')
+            if not containers_config_auth_file:
+                containers_config_auth_file = os.path.join(
+                    self.work_dir_path,
+                    'container-auth.json'
+                )
             container_registries_login(
                 registries=self.get_value('container-registries'),
                 containers_config_auth_file=containers_config_auth_file,
-                containers_config_tls_verify=util.strtobool(dest_tls_verify)
+                containers_config_tls_verify=dest_tls_verify
             )
 
             # push image
             sh.skopeo.copy( # pylint: disable=no-member
-                f"--src-tls-verify={str(self.get_value('src-tls-verify'))}",
-                f"--dest-tls-verify={str(self.get_value('dest-tls-verify'))}",
+                f"--src-tls-verify={str(source_tls_verify).lower()}",
+                f"--dest-tls-verify={str(dest_tls_verify).lower()}",
                 f"--authfile={containers_config_auth_file}",
-                f'docker-archive:{image_tar_file}',
-                f'docker://{image_tag}',
+                f'{pull_repository_type}{image_pull_tag}',
+                f'{push_repository_type}{image_push_tag}',
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
             )
         except sh.ErrorReturnCode as error:
             step_result.success = False
-            step_result.message = f'Error pushing container image ({image_tar_file}) ' \
-                f' to tag ({image_tag}) using skopeo: {error}'
+            step_result.message = f'Error pushing container image ({image_pull_tag}) ' \
+                f' to tag ({image_push_tag}) using skopeo: {error}'
 
-        step_result.add_artifact(name='container-image-registry-uri', value=image_registry_uri)
+        # add artifacts
+        step_result.add_artifact(
+            name='container-image-registry-uri',
+            value=image_registry_uri,
+            description='Registry URI poriton of the container image tag' \
+                ' of the pushed container image.'
+        )
         step_result.add_artifact(
             name='container-image-registry-organization',
-            value=image_registry_organization
+            value=image_registry_organization,
+            description='Organization portion of the container image tag' \
+                ' of the pushed container image.'
         )
-        step_result.add_artifact(name='container-image-repository', value=image_repository)
-        step_result.add_artifact(name='container-image-name', value=image_repository)
-        step_result.add_artifact(name='container-image-version', value=image_version)
-        step_result.add_artifact(name='container-image-tag', value=image_tag)
+        step_result.add_artifact(
+            name='container-image-repository',
+            value=image_repository,
+            description='Repository portion of the container image tag' \
+                ' of the pushed container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-name',
+            value=image_repository,
+            description='Another way to reference the' \
+                ' repository portion of the container image tag of the pushed container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-version',
+            value=image_version,
+            description='Version portion of the container image tag of the pushed container image.'
+        )
+        step_result.add_artifact(
+            name='container-image-tag',
+            value=image_push_tag,
+            description='Full container image tag of the pushed container,' \
+                ' including the registry URI.'
+        )
+        step_result.add_artifact(
+            name='container-image-short-tag',
+            value=image_push_short_tag,
+            description='Short container image tag of the pushed container image,' \
+                ' excluding the registry URI.'
+        )
 
         return step_result

--- a/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
+++ b/tests/step_implementers/container_image_static_compliance_scan/test_openscap_compliance.py
@@ -1,14 +1,15 @@
 import os
 import re
 
-from testfixtures import TempDirectory
-from tests.step_implementers.shared.test_openscap_generic import \
-    TestStepImplementerSharedOpenSCAPGeneric
+import tests.step_implementers.shared.test_openscap_generic
 from ploigos_step_runner.step_implementers.container_image_static_compliance_scan import \
     OpenSCAP
+from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
 
 
-class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImplementerSharedOpenSCAPGeneric):
+class BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -26,123 +27,52 @@ class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP(TestStepImpl
             parent_work_dir_path=parent_work_dir_path
         )
 
-    def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
-        step_config = {
-            'oscap-input-definitions-uri': 'https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds.xml',
-            'oscap-profile': 'foo',
-            'image-tar-file': 'does-not-matter'
-        }
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP_step_implementer_config_defaults(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric_step_implementer_config_defaults
+):
+    pass
 
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP__required_config_or_result_keys(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP
+):
+    def test_result(self):
+        required_keys = OpenSCAP._required_config_or_result_keys()
+        expected_required_keys = [
+            'oscap-profile',
+            'oscap-input-definitions-uri',
+            'container-image-tag',
+            'container-image-pull-repository-type',
+            ['container-image-pull-repository-type', 'container-image-repository-type']
+        ]
+        self.assertEqual(required_keys, expected_required_keys)
 
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='test',
-                implementer='OpenSCAP',
-                parent_work_dir_path=parent_work_dir_path
-            )
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP__validate_required_config_or_previous_step_result_artifact_keys(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric__validate_required_config_or_previous_step_result_artifact_keys
+):
+    pass
 
-            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP___get_oscap_document_type(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___get_oscap_document_type
+):
+    pass
 
-    def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_extension(self):
-        oscap_input_definitions_uri = 'https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds.xml.foo'
-        step_config = {
-            'oscap-input-definitions-uri': oscap_input_definitions_uri,
-            'oscap-profile': 'foo',
-            'image-tar-file': 'does-not-matter'
-        }
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP___get_oscap_eval_type_based_on_document_type(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___get_oscap_eval_type_based_on_document_type
+):
+    pass
 
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP___run_oscap_scan(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___run_oscap_scan
+):
+    pass
 
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='test',
-                implementer='OpenSCAP',
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            with self.assertRaisesRegex(
-                    AssertionError,
-                    re.compile(
-                        r'Open SCAP input definitions source '
-                        rf'\({oscap_input_definitions_uri}\) must be of known type \(xml\|bz2\), got: \.foo'
-                    )
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
-
-    def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_protocal(self):
-        oscap_input_definitions_uri = 'foo://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds.xml'
-        step_config = {
-            'oscap-input-definitions-uri': oscap_input_definitions_uri,
-            'oscap-profile': 'foo',
-            'image-tar-file': 'does-not-matter'
-        }
-
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='test',
-                implementer='OpenSCAP',
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            with self.assertRaisesRegex(
-                    AssertionError,
-                    re.compile(
-                        r'Open SCAP input definitions source '
-                        rf'\({oscap_input_definitions_uri}\) must start with known protocol '
-                        r'\(file://\|http://\|https://\)\.'
-                    )
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
-
-    def test__validate_required_config_or_previous_step_result_artifact_keys_missing_oscap_profile(self):
-        oscap_input_definitions_uri = 'https://atopathways.redhatgov.io/compliance-as-code/scap/ssg-rhel8-ds.xml'
-        step_config = {
-            'oscap-input-definitions-uri': oscap_input_definitions_uri,
-            'image-tar-file': 'does-not-matter'
-        }
-
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='test',
-                implementer='OpenSCAP',
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            with self.assertRaisesRegex(
-                    AssertionError,
-                    re.compile(
-                        r"Missing required step configuration or previous step result"
-                        r" artifact keys: \['oscap-profile'\]"
-                    )
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
-
-    def test__validate_required_config_or_previous_step_result_artifact_keys_missing_required_keys(self):
-        step_config = {}
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='test',
-                implementer='OpenSCAP',
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            with self.assertRaisesRegex(
-                    AssertionError,
-                    re.compile(
-                        r"Missing required step configuration or previous step result"
-                        r" artifact keys: \['oscap-profile', 'oscap-input-definitions-uri', 'image-tar-file'\]"
-                    )
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+class TestStepImplementerContainerImageStaticComplianceScanOpenSCAP__run_step(
+    BaseTestStepImplementerContainerImageStaticComplianceScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric__run_step
+):
+    pass

--- a/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
+++ b/tests/step_implementers/container_image_static_vulnerability_scan/test_openscap_vulnerability.py
@@ -1,10 +1,11 @@
-from tests.step_implementers.shared.test_openscap_generic import \
-    TestStepImplementerSharedOpenSCAPGeneric
+import tests.step_implementers.shared.test_openscap_generic
 from ploigos_step_runner.step_implementers.container_image_static_vulnerability_scan import \
     OpenSCAP
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
 
 
-class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepImplementerSharedOpenSCAPGeneric):
+class BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -21,3 +22,45 @@ class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP(TestStepI
             workflow_result=workflow_result,
             parent_work_dir_path=parent_work_dir_path
         )
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP_step_implementer_config_defaults(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric_step_implementer_config_defaults
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP__required_config_or_result_keys(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric__required_config_or_result_keys
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP__validate_required_config_or_previous_step_result_artifact_keys(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric__validate_required_config_or_previous_step_result_artifact_keys
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP___get_oscap_document_type(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___get_oscap_document_type
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP___get_oscap_eval_type_based_on_document_type(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___get_oscap_eval_type_based_on_document_type
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP___run_oscap_scan(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric___run_oscap_scan
+):
+    pass
+
+class TestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP__run_step(
+    BaseTestStepImplementerContainerImageStaticVulnerabilityScanOpenSCAP,
+    tests.step_implementers.shared.test_openscap_generic.TestStepImplementerSharedOpenSCAPGeneric__run_step
+):
+    pass

--- a/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
+++ b/tests/step_implementers/create_container_image/test_buildah_create_container_image.py
@@ -13,7 +13,7 @@ from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
 
 
-class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase):
+class BaseTestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -31,11 +31,114 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             parent_work_dir_path=parent_work_dir_path
         )
 
-# TESTS FOR configuration checks
-    def test_step_implementer_config_defaults(self):
+@patch("ploigos_step_runner.StepImplementer._validate_required_config_or_previous_step_result_artifact_keys")
+class TestStepImplementerCreateContainerImageBuildah__validate_required_config_or_previous_step_result_artifact_keys(
+    BaseTestStepImplementerCreateContainerImageBuildah
+):
+    def test_valid_defaults(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            # setup
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+            step_config = {
+                'context': test_dir.path,
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name'
+            }
+            test_dir.write('Containerfile',b'''testing''')
+
+            # run test
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+            # validate
+            mock_super_validate.assert_called_once_with()
+
+    def test_valid_custom_imagespecfile(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            # setup
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+            step_config = {
+                'context': test_dir.path,
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name',
+                'imagespecfile': 'MockContainerfile.ubi8'
+            }
+            test_dir.write('MockContainerfile.ubi8',b'''testing''')
+
+            # run test
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+            # validate
+            mock_super_validate.assert_called_once_with()
+
+    def test_fail_missing_imagespecfile_defaults(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            # setup
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+            step_config = {
+                'context': test_dir.path,
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name'
+            }
+
+            # run test
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+            with self.assertRaisesRegex(
+                AssertionError,
+                rf'Given imagespecfile \(Containerfile\) does not exist'
+                rf' in given context \({test_dir.path}\).'
+            ):
+                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+            # validate
+            mock_super_validate.assert_called_once_with()
+
+    def test_fail_missing_imagespecfile_custom_imagespecfile(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            # setup
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+            step_config = {
+                'context': test_dir.path,
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name',
+                'imagespecfile': 'MockContainerfile.ubi8'
+            }
+
+            # run test
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+            with self.assertRaisesRegex(
+                AssertionError,
+                rf'Given imagespecfile \(MockContainerfile.ubi8\) does not exist'
+                rf' in given context \({test_dir.path}\).'
+            ):
+                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+            # validate
+            mock_super_validate.assert_called_once_with()
+
+class TestStepImplementerCreateContainerImageBuildah_step_implementer_config_defaults(
+    BaseTestStepImplementerCreateContainerImageBuildah
+):
+    def test_result(self):
         defaults = Buildah.step_implementer_config_defaults()
         expected_defaults = {
-            'containers-config-auth-file': os.path.join(Path.home(), '.buildah-auth.json'),
             'imagespecfile': 'Containerfile',
             'context': '.',
             'tls-verify': True,
@@ -43,22 +146,29 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
         }
         self.assertEqual(defaults, expected_defaults)
 
-    def test__required_config_or_result_keys(self):
+class TestStepImplementerCreateContainerImageBuildah___required_config_or_result_keys(
+    BaseTestStepImplementerCreateContainerImageBuildah
+):
+    def test_result(self):
         required_keys = Buildah._required_config_or_result_keys()
         expected_required_keys = [
-            'containers-config-auth-file',
             'imagespecfile',
             'context',
             'tls-verify',
             'format',
+            'organization',
             'service-name',
             'application-name'
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
+class TestStepImplementerCreateContainerImageBuildah___run_step(
+    BaseTestStepImplementerCreateContainerImageBuildah
+):
     @patch('sh.buildah', create=True)
-    def test__run_step_pass(self, buildah_mock):
+    def test_pass(self, buildah_mock):
         with TempDirectory() as temp_dir:
+            # setup test
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Containerfile',b'''testing''')
 
@@ -68,11 +178,11 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
             workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
             step_config = {
-                'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Containerfile',
                 'context': temp_dir.path,
                 'tls-verify': True,
                 'format': 'oci',
+                'organization': 'org-name',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
@@ -84,62 +194,272 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 parent_work_dir_path=parent_work_dir_path
             )
 
-
-
+            # run test
             result = step_implementer._run_step()
 
+            # verify results
             expected_step_result = StepResult(
                 step_name='create-container-image',
                 sub_step_name='Buildah',
                 sub_step_implementer_name='Buildah'
             )
             expected_step_result.add_artifact(
-                name='container-image-version',
-                value='localhost/app-name/service-name:1.0-123abc'
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
             )
             expected_step_result.add_artifact(
-                name='image-tar-file',
-                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar'
+                name='container-image-registry-organization',
+                value='org-name',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
             )
-
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='app-name-service-name',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='app-name-service-name',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='1.0-123abc',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/org-name/app-name-service-name:1.0-123abc',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='org-name/app-name-service-name:1.0-123abc',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+            self.assertEqual(result, expected_step_result)
 
             buildah_mock.bud.assert_called_once_with(
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers', '-f', 'Containerfile',
-                '-t', 'localhost/app-name/service-name:1.0-123abc',
-                '--authfile', 'buildah-auth.json',
+                '-t', 'localhost/org-name/app-name-service-name:1.0-123abc',
+                '--authfile', os.path.join(step_implementer.work_dir_path, 'container-auth.json'),
                 temp_dir.path,
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
             )
 
-            buildah_mock.push.assert_called_once_with(
-                'localhost/app-name/service-name:1.0-123abc',
-                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-            self.assertEqual(result, expected_step_result)
-
     @patch('sh.buildah', create=True)
-    def test__run_step_pass_no_container_image_version(self, buildah_mock):
+    def test_pass_custom_auth_file(self, buildah_mock):
         with TempDirectory() as temp_dir:
+            # setup test
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Containerfile',b'''testing''')
 
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
             step_config = {
-                'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': 'Containerfile',
                 'context': temp_dir.path,
                 'tls-verify': True,
                 'format': 'oci',
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name',
+                'containers-config-auth-file': 'mock-auth.json'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='create-container-image',
+                implementer='Buildah',
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            # run test
+            result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='create-container-image',
+                sub_step_name='Buildah',
+                sub_step_implementer_name='Buildah'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-organization',
+                value='org-name',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='app-name-service-name',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='app-name-service-name',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='1.0-123abc',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/org-name/app-name-service-name:1.0-123abc',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='org-name/app-name-service-name:1.0-123abc',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+            self.assertEqual(result, expected_step_result)
+
+            buildah_mock.bud.assert_called_once_with(
+                '--format=oci',
+                '--tls-verify=true',
+                '--layers', '-f', 'Containerfile',
+                '-t', 'localhost/org-name/app-name-service-name:1.0-123abc',
+                '--authfile', 'mock-auth.json',
+                temp_dir.path,
+                _out=sys.stdout,
+                _err=sys.stderr,
+                _tee='err'
+            )
+
+    @patch('sh.buildah', create=True)
+    def test_pass_string_tls_verify(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            # setup test
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+            temp_dir.write('Containerfile',b'''testing''')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-123abc'},
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'imagespecfile': 'Containerfile',
+                'context': temp_dir.path,
+                'tls-verify': 'true',
+                'format': 'oci',
+                'organization': 'org-name',
                 'service-name': 'service-name',
                 'application-name': 'app-name'
             }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='create-container-image',
+                implementer='Buildah',
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
 
+            # run test
+            result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='create-container-image',
+                sub_step_name='Buildah',
+                sub_step_implementer_name='Buildah'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-organization',
+                value='org-name',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='app-name-service-name',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='app-name-service-name',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='1.0-123abc',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/org-name/app-name-service-name:1.0-123abc',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='org-name/app-name-service-name:1.0-123abc',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+            self.assertEqual(result, expected_step_result)
+
+            buildah_mock.bud.assert_called_once_with(
+                '--format=oci',
+                '--tls-verify=true',
+                '--layers', '-f', 'Containerfile',
+                '-t', 'localhost/org-name/app-name-service-name:1.0-123abc',
+                '--authfile', os.path.join(step_implementer.work_dir_path, 'container-auth.json'),
+                temp_dir.path,
+                _out=sys.stdout,
+                _err=sys.stderr,
+                _tee='err'
+            )
+
+    @patch('sh.buildah', create=True)
+    def test_pass_no_container_image_version(self, buildah_mock):
+        with TempDirectory() as temp_dir:
+            # setup test
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+            temp_dir.write('Containerfile',b'''testing''')
+            step_config = {
+                'imagespecfile': 'Containerfile',
+                'context': temp_dir.path,
+                'tls-verify': True,
+                'format': 'oci',
+                'organization': 'org-name',
+                'service-name': 'service-name',
+                'application-name': 'app-name'
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='create-container-image',
@@ -147,147 +467,72 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 parent_work_dir_path=parent_work_dir_path,
             )
 
+            # run test
             result = step_implementer._run_step()
 
+            # verify results
             expected_step_result = StepResult(
                 step_name='create-container-image',
                 sub_step_name='Buildah',
                 sub_step_implementer_name='Buildah'
             )
             expected_step_result.add_artifact(
-                name='container-image-version',
-                value='localhost/app-name/service-name:latest'
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
             )
             expected_step_result.add_artifact(
-                name='image-tar-file',
-                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-latest.tar'
+                name='container-image-registry-organization',
+                value='org-name',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
             )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='app-name-service-name',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='app-name-service-name',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='latest',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/org-name/app-name-service-name:latest',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='org-name/app-name-service-name:latest',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+            self.assertEqual(result, expected_step_result)
 
             buildah_mock.bud.assert_called_once_with(
                 '--format=oci',
                 '--tls-verify=true',
                 '--layers', '-f', 'Containerfile',
-                '-t', 'localhost/app-name/service-name:latest',
-                '--authfile', 'buildah-auth.json',
+                '-t', 'localhost/org-name/app-name-service-name:latest',
+                '--authfile', os.path.join(step_implementer.work_dir_path, 'container-auth.json'),
                 temp_dir.path,
                 _out=sys.stdout,
                 _err=sys.stderr,
                 _tee='err'
             )
 
-            buildah_mock.push.assert_called_once_with(
-                'localhost/app-name/service-name:latest',
-                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-latest.tar',
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-            self.assertEqual(result, expected_step_result)
-
     @patch('sh.buildah', create=True)
-    def test__run_step_pass_image_tar_file_exists(self, buildah_mock):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            temp_dir.write('Containerfile',b'''testing''')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'containers-config-auth-file': 'buildah-auth.json',
-                'imagespecfile': 'Containerfile',
-                'context': temp_dir.path,
-                'tls-verify': True,
-                'format': 'oci',
-                'service-name': 'service-name',
-                'application-name': 'app-name'
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='create-container-image',
-                implementer='Buildah',
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            step_implementer.write_working_file('image-app-name-service-name-1.0-123abc.tar')
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(
-                step_name='create-container-image',
-                sub_step_name='Buildah',
-                sub_step_implementer_name='Buildah'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-version',
-                value='localhost/app-name/service-name:1.0-123abc'
-            )
-            expected_step_result.add_artifact(
-                name='image-tar-file',
-                value=f'{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar'
-            )
-
-
-            buildah_mock.bud.assert_called_once_with(
-                '--format=oci',
-                '--tls-verify=true',
-                '--layers', '-f', 'Containerfile',
-                '-t', 'localhost/app-name/service-name:1.0-123abc',
-                '--authfile', 'buildah-auth.json',
-                temp_dir.path,
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-
-            buildah_mock.push.assert_called_once_with(
-                'localhost/app-name/service-name:1.0-123abc',
-                f'docker-archive:{step_implementer.work_dir_path}/image-app-name-service-name-1.0-123abc.tar',
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-            self.assertEqual(result, expected_step_result)
-
-    @patch('sh.buildah', create=True)
-    def test__run_step_fail_no_image_spec_file(self, buildah_mock):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-123abc'},
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'service-name': 'service-name',
-                'application-name': 'app-name'
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='create-container-image',
-                implementer='Buildah',
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(
-                step_name='create-container-image',
-                sub_step_name='Buildah',
-                sub_step_implementer_name='Buildah'
-            )
-            expected_step_result.success = False
-            expected_step_result.message = 'Image specification file does not exist in location: ./Containerfile'
-
-            self.assertEqual(result, expected_step_result)
-
-    @patch('sh.buildah', create=True)
-    def test__run_step_fail_buildah_bud_error(self, buildah_mock):
+    def test_fail_buildah_bud_error(self, buildah_mock):
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             temp_dir.write('Containerfile',b'''testing''')
@@ -299,7 +544,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
 
             image_spec_file = 'Containerfile'
             step_config = {
-                'containers-config-auth-file': 'buildah-auth.json',
                 'imagespecfile': image_spec_file,
                 'context': temp_dir.path,
                 'tls-verify': True,
@@ -325,60 +569,6 @@ class TestStepImplementerCreateContainerImageBuildah(BaseStepImplementerTestCase
                 re.compile(
                     r'Issue invoking buildah bud with given image '
                     rf'specification file \({image_spec_file}\):'
-                    r'.*RAN: buildah'
-                    r'.*STDOUT:'
-                    r'.*mock out'
-                    r'.*STDERR:'
-                    r'.*mock error',
-                    re.DOTALL
-                )
-            )
-
-    @patch('sh.buildah', create=True)
-    def test__run_step_fail_buildah_push_error(self, buildah_mock):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            temp_dir.write('Containerfile',b'''testing''')
-
-            application_name = 'app-name'
-            service_name = 'service-name'
-            image_tag_version = '1.0-123abc'
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': image_tag_version},
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'containers-config-auth-file': 'buildah-auth.json',
-                'imagespecfile': 'Containerfile',
-                'context': temp_dir.path,
-                'tl-sverify': 'true',
-                'format': 'oci',
-                'service-name': service_name,
-                'application-name': application_name
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='create-container-image',
-                implementer='Buildah',
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            buildah_mock.push.side_effect = sh.ErrorReturnCode('buildah', b'mock out', b'mock error')
-
-            result = step_implementer._run_step()
-
-            image_tar_path = os.path.join(
-                step_implementer.work_dir_path,
-                f'image-{application_name}-{service_name}-{image_tag_version}.tar'
-            )
-            self.assertFalse(result.success)
-            self.assertRegex(
-                result.message,
-                re.compile(
-                    rf'Issue invoking buildah push to tar file \({image_tar_path}\):'
                     r'.*RAN: buildah'
                     r'.*STDOUT:'
                     r'.*mock out'

--- a/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
+++ b/tests/step_implementers/push_container_image/test_skopeo_push_container_image.py
@@ -1,22 +1,17 @@
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
-# pylint: disable=missing-function-docstring
 import os
-import re
 from io import IOBase
-from pathlib import Path
 from unittest.mock import patch
 
 import sh
+from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.push_container_image import Skopeo
 from testfixtures import TempDirectory
 from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
 from tests.helpers.test_utils import Any
-from ploigos_step_runner.step_implementers.push_container_image import Skopeo
-from ploigos_step_runner import StepResult
 
 
-class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
+class BaseTestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -34,122 +29,320 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             parent_work_dir_path=parent_work_dir_path
         )
 
-    def test_step_implementer_config_defaults(self):
+class TestStepImplementerSkopeoSourceBase_step_implementer_config_defaults(
+    BaseTestStepImplementerSkopeoSourceBase
+):
+    def test_result(self):
         defaults = Skopeo.step_implementer_config_defaults()
         expected_defaults = {
-            'containers-config-auth-file': os.path.join(
-                Path.home(),
-                '.container-image-repo-auth.json'
-            ),
-            'dest-tls-verify': 'true',
-            'src-tls-verify': 'true'
+            'src-tls-verify': True,
+            'dest-tls-verify': True,
+            'container-image-pull-repository-type': 'containers-storage:',
+            'container-image-push-repository-type': 'docker://'
         }
         self.assertEqual(defaults, expected_defaults)
 
-    def test__required_config_or_result_keys(self):
+class TestStepImplementerSkopeoSourceBase___required_config_or_result_keys(
+    BaseTestStepImplementerSkopeoSourceBase
+):
+    def test_result(self):
         required_keys = Skopeo._required_config_or_result_keys()
         expected_required_keys = [
-            'containers-config-auth-file',
             'destination-url',
-            'src-tls-verify',
+            ['source-tls,verify', 'src-tls-verify'],
             'dest-tls-verify',
             'service-name',
             'application-name',
             'organization',
-            'container-image-version',
-            'image-tar-file'
+            ['container-image-pull-tag', 'container-image-tag'],
+            ['container-image-pull-repository-type', 'container-image-repository-type'],
+            ['container-image-push-repository-type', 'container-image-repository-type']
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
-    @patch.object(sh, 'skopeo', create=True)
-    def test_run_step_pass(self, skopeo_mock):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+class TestStepImplementerSkopeoSourceBase__run_step(
+    BaseTestStepImplementerSkopeoSourceBase
+):
+    def __run_pass_test(
+        self,
+        step_config,
+        image_version,
+        image_pull_tag,
+        image_push_tag,
+        temp_dir,
+        skopeo_mock,
+        skopeo_mock_call_dest_tls_value='true',
+        skopeo_mock_call_src_tls_value='true',
+        expected_step_result_message=None,
+        containers_config_auth_file=None
+    ):
+        parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
-            image_tar_file = 'fake-image.tar'
-            image_version = '1.0-69442c8'
-            image_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
-            step_config = {
-                'destination-url': 'fake-registry.xyz',
-                'service-name': 'fake-service',
-                'application-name': 'fake-app',
-                'organization': 'fake-org',
-                'container-image-version': image_version,
-                'image-tar-file': image_tar_file
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='push-container-image',
-                implementer='Skopeo',
-                parent_work_dir_path=parent_work_dir_path,
-            )
+        # setup step
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='push-container-image',
+            implementer='Skopeo',
+            parent_work_dir_path=parent_work_dir_path,
+        )
 
-            result = step_implementer._run_step()
+        # run step
+        result = step_implementer._run_step()
 
-            expected_step_result = StepResult(
-                step_name='push-container-image',
-                sub_step_name='Skopeo',
-                sub_step_implementer_name='Skopeo'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-registry-uri',
-                value='fake-registry.xyz'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-registry-organization',
-                value='fake-org'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-repository',
-                value='fake-app-fake-service'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-name',
-                value='fake-app-fake-service'
-            )
-            expected_step_result.add_artifact(
-                name='container-image-version',
-                value=image_version
-            )
-            expected_step_result.add_artifact(
-                name='container-image-tag',
-                value='fake-registry.xyz/fake-org/fake-app-fake-service:1.0-69442c8'
-            )
-            self.assertEqual(
-                result.get_step_result_dict(),
-                expected_step_result.get_step_result_dict()
-            )
+        # verify
+        expected_step_result = StepResult(
+            step_name='push-container-image',
+            sub_step_name='Skopeo',
+            sub_step_implementer_name='Skopeo'
+        )
+        if expected_step_result_message:
+            expected_step_result.message = expected_step_result_message
+        expected_step_result.add_artifact(
+            name='container-image-registry-uri',
+            value='fake-registry.xyz',
+            description='Registry URI poriton of the container image tag' \
+                ' of the pushed container image.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-registry-organization',
+            value='fake-org',
+            description='Organization portion of the container image tag' \
+                ' of the pushed container image.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-repository',
+            value='fake-app-fake-service',
+            description='Repository portion of the container image tag' \
+                ' of the pushed container image.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-name',
+            value='fake-app-fake-service',
+            description='Another way to reference the' \
+                ' repository portion of the container image tag of the pushed container image.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-version',
+            value=image_version,
+            description='Version portion of the container image tag of the pushed container image.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value=f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}',
+            description='Full container image tag of the pushed container,' \
+                ' including the registry URI.'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-short-tag',
+            value=f'fake-org/fake-app-fake-service:{image_version}',
+            description='Short container image tag of the pushed container image,' \
+                ' excluding the registry URI.'
+        )
+        self.assertEqual(result, expected_step_result)
 
+        if not containers_config_auth_file:
             containers_config_auth_file = os.path.join(
-                Path.home(),
-                '.container-image-repo-auth.json'
+                step_implementer.work_dir_path,
+                'container-auth.json'
             )
-            skopeo_mock.copy.assert_called_once_with(
-                "--src-tls-verify=true",
-                "--dest-tls-verify=true",
-                f"--authfile={containers_config_auth_file}",
-                f'docker-archive:{image_tar_file}',
-                f'docker://{image_tag}',
-                _out=Any(IOBase),
-                _err=Any(IOBase),
-                _tee='err'
-            )
+
+        skopeo_mock.copy.assert_called_once_with(
+            f"--src-tls-verify={skopeo_mock_call_src_tls_value}",
+            f"--dest-tls-verify={skopeo_mock_call_dest_tls_value}",
+            f"--authfile={containers_config_auth_file}",
+            f'containers-storage:{image_pull_tag}',
+            f'docker://{image_push_tag}',
+            _out=Any(IOBase),
+            _err=Any(IOBase),
+            _tee='err'
+        )
 
     @patch.object(sh, 'skopeo', create=True)
-    def test_run_step_fail_run_skopeo(self, skopeo_mock):
+    def test_pass(self, skopeo_mock):
         with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            image_tar_file = 'fake-image.tar'
             image_version = '1.0-69442c8'
-            image_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
             step_config = {
                 'destination-url': 'fake-registry.xyz',
                 'service-name': 'fake-service',
                 'application-name': 'fake-app',
                 'organization': 'fake-org',
                 'container-image-version': image_version,
-                'image-tar-file': image_tar_file
+                'container-image-pull-tag': image_pull_tag
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_default_version(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = 'latest'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-pull-tag': image_pull_tag
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock
+            )
+
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_string_destination_tls_truethy(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag,
+                'dest-tls-verify': 'true'
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_string_destination_tls_falsy(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag,
+                'dest-tls-verify': 'false'
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock,
+                skopeo_mock_call_dest_tls_value='false'
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_string_source_tls_truthy(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag,
+                'src-tls-verify': 'true'
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_string_source_tls_falsy(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag,
+                'src-tls-verify': 'false'
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock,
+                skopeo_mock_call_src_tls_value='false'
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_pass_custom_auth_file(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag,
+                'containers-config-auth-file': 'mock-auth.json'
+            }
+            self.__run_pass_test(
+                temp_dir=temp_dir,
+                image_version=image_version,
+                image_pull_tag=image_pull_tag,
+                image_push_tag=image_push_tag,
+                step_config=step_config,
+                skopeo_mock=skopeo_mock,
+                containers_config_auth_file='mock-auth.json'
+            )
+
+    @patch.object(sh, 'skopeo', create=True)
+    def test_fail_run_skopeo(self, skopeo_mock):
+        with TempDirectory() as temp_dir:
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # setup step
+            image_version = '1.0-69442c8'
+            image_pull_tag = f'localhost/fake-org/fake-app-fake-service:{image_version}'
+            image_push_tag = f'fake-registry.xyz/fake-org/fake-app-fake-service:{image_version}'
+            step_config = {
+                'destination-url': 'fake-registry.xyz',
+                'service-name': 'fake-service',
+                'application-name': 'fake-app',
+                'organization': 'fake-org',
+                'container-image-version': image_version,
+                'container-image-version': image_version,
+                'container-image-pull-tag': image_pull_tag
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
@@ -158,9 +351,11 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path,
             )
 
+            # run step (mock fail)
             skopeo_mock.copy.side_effect = sh.ErrorReturnCode('skopeo', b'mock stdout', b'mock error')
             result = step_implementer._run_step()
 
+            # verify
             expected_step_result = StepResult(
                 step_name='push-container-image',
                 sub_step_name='Skopeo',
@@ -168,31 +363,48 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(
                 name='container-image-registry-uri',
-                value='fake-registry.xyz'
+                value='fake-registry.xyz',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the pushed container image.'
             )
             expected_step_result.add_artifact(
                 name='container-image-registry-organization',
-                value='fake-org'
+                value='fake-org',
+                description='Organization portion of the container image tag' \
+                    ' of the pushed container image.'
             )
             expected_step_result.add_artifact(
                 name='container-image-repository',
-                value='fake-app-fake-service'
+                value='fake-app-fake-service',
+                description='Repository portion of the container image tag' \
+                    ' of the pushed container image.'
             )
             expected_step_result.add_artifact(
                 name='container-image-name',
-                value='fake-app-fake-service'
+                value='fake-app-fake-service',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the pushed container image.'
             )
             expected_step_result.add_artifact(
                 name='container-image-version',
-                value=image_version
+                value=image_version,
+                description='Version portion of the container image tag of the pushed container image.'
             )
             expected_step_result.add_artifact(
                 name='container-image-tag',
-                value='fake-registry.xyz/fake-org/fake-app-fake-service:1.0-69442c8'
+                value='fake-registry.xyz/fake-org/fake-app-fake-service:1.0-69442c8',
+                description='Full container image tag of the pushed container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='fake-org/fake-app-fake-service:1.0-69442c8',
+                description='Short container image tag of the pushed container image,' \
+                    ' excluding the registry URI.'
             )
             expected_step_result.success = False
-            expected_step_result.message = f"Error pushing container image ({image_tar_file}) " +\
-                f" to tag ({image_tag}) using skopeo: \n" +\
+            expected_step_result.message = f"Error pushing container image ({image_pull_tag}) " +\
+                f" to tag ({image_push_tag}) using skopeo: \n" +\
                 f"\n" +\
                 f"  RAN: skopeo\n" +\
                 f"\n" +\
@@ -201,19 +413,18 @@ class TestStepImplementerSkopeoSourceBase(BaseStepImplementerTestCase):
                 f"\n" +\
                 f"  STDERR:\n" +\
                 f"mock error"
-
             self.assertEqual(result, expected_step_result)
 
             containers_config_auth_file = os.path.join(
-                Path.home(),
-                '.container-image-repo-auth.json'
+                step_implementer.work_dir_path,
+                'container-auth.json'
             )
             skopeo_mock.copy.assert_called_once_with(
                 "--src-tls-verify=true",
                 "--dest-tls-verify=true",
                 f"--authfile={containers_config_auth_file}",
-                f'docker-archive:{image_tar_file}',
-                f'docker://{image_tag}',
+                f'containers-storage:{image_pull_tag}',
+                f'docker://{image_push_tag}',
                 _out=Any(IOBase),
                 _err=Any(IOBase),
                 _tee='err'

--- a/tests/step_implementers/sign_container_image/test_podman_sign.py
+++ b/tests/step_implementers/sign_container_image/test_podman_sign.py
@@ -97,7 +97,7 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
         required_keys = PodmanSign._required_config_or_result_keys()
         expected_required_keys = [
             ['signer-pgp-private-key', 'container-image-signer-pgp-private-key'],
-            'container-image-tag'
+            ['container-image-push-tag', 'container-image-tag']
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
@@ -162,11 +162,14 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 containers_config_tls_verify=True,
                 container_command_short_name='podman'
             )
-
             expected_step_result = StepResult(
                 step_name='sign-container-image',
                 sub_step_name='PodmanSign',
                 sub_step_implementer_name='PodmanSign'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-signed-tag',
+                value=container_image_tag,
             )
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
@@ -255,6 +258,10 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 sub_step_name='PodmanSign',
                 sub_step_implementer_name='PodmanSign'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-signed-tag',
+                value=container_image_tag,
             )
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
@@ -358,6 +365,14 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 step_name='sign-container-image',
                 sub_step_name='PodmanSign',
                 sub_step_implementer_name='PodmanSign'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-signed-tag',
+                value=container_image_tag,
+            )
+            expected_step_result.add_artifact(
+                name='container-image-signed-tag',
+                value=container_image_tag,
             )
             expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
@@ -464,6 +479,10 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
                 sub_step_implementer_name='PodmanSign'
             )
             expected_step_result.add_artifact(
+                name='container-image-signed-tag',
+                value=container_image_tag,
+            )
+            expected_step_result.add_artifact(
                 name='container-image-signature-file-path',
                 value= os.path.join(
                     parent_work_dir_path,
@@ -487,9 +506,8 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = 'mock upload error'
 
-            print(expected_step_result)
-            print(result)
             self.assertEqual(expected_step_result, result)
+
     @patch('ploigos_step_runner.step_implementers.sign_container_image.podman_sign.import_pgp_key')
     @patch.object(PodmanSign, '_PodmanSign__sign_image')
     def test_run_step_fail_import_pgp_key(self, sign_image_mock, import_pgp_key_mock):
@@ -538,8 +556,6 @@ class TestStepImplementerSignContainerImagePodman(BaseStepImplementerTestCase):
             expected_step_result.success = False
             expected_step_result.message = 'mock error importing pgp key'
 
-            print(expected_step_result)
-            print(result)
             self.assertEqual(expected_step_result, result)
 
     @patch('ploigos_step_runner.step_implementers.sign_container_image.podman_sign.import_pgp_key')


### PR DESCRIPTION
# purpose

currently we build container images and then turn them into a tar that gets passed around until pushing the container image to an external registry.

This is unnecessary translation overhead and makes things more complicated then they need to be.

# proposal

rely on shared container image storage between steps so as not to have to translate the container image into tar to pass around

# integration testing

## jenkins

- [x] [minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-28/4/)
- [x] [typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-quarkus-mvn/view/change-requests/job/PR-28/7/)
- [x] [everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-28/6/)

## tekton

- [X] [minimal](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-quarkus-mvn-tekton-min-fruit-glyzp7/)
- [x] [typical](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-quarkus-mvn-tekton-typ-fruit-cn5dnr/)
- [x] [everything](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-quarkus-mvn-tekton-eve-fruit-2lxwvm)

# background

Decided to do this because of work started on creating a Maven JKube StepImplementer for buidling container images, which builds a container image into the lcoal container storage, and relaized i would have to turn that into a tar to integrate with rest of steps, and rather then doing that, realized, probably just shouln't be turning container image into tar

# breaking

* This will break any workflow that doesn't mount shared storage for wherever the container storage is for the workflow runner container images used to run container manipulation steps.
  - this isn't a problem for the reference ploigos workflow sbecause they all mount `${HOME}` to a shared persistent volume, and by default buildah/podman use a directory under `${HOME}` when doing rootless container operations, but if someone made their own workflow that didn't do that it would be a probelm.
* steps no longer except the `container-tar-file` parameter (didn't seem wroth effort for backwards compatibility) BUT you can still pass in a path via the `container-image-tag` parameter and change the new `container-image-(*-)repository-type` respective parameter to `docker-archive:` if you really really want to import from a tar file

# related
* https://github.com/ploigos/ploigos-jenkins-library/pull/54