### PR TITLE
add continue sub steps on failure option

### DIFF
--- a/src/ploigos_step_runner/config/step_config.py
+++ b/src/ploigos_step_runner/config/step_config.py
@@ -102,11 +102,13 @@ class StepConfig:
         self.__step_config_overrides = step_config_overrides if step_config_overrides else {}
 
     def add_or_update_sub_step_config(
-            self,
-            sub_step_name,
-            sub_step_implementer_name,
-            sub_step_config_dict=None,
-            sub_step_env_config=None):
+        self,
+        sub_step_name,
+        sub_step_implementer_name,
+        sub_step_config_dict=None,
+        sub_step_env_config=None,
+        sub_step_contine_sub_steps_on_failure=False
+    ): # pylint: disable=too-many-arguments
         """Add a new or update an existing sub step configuration for this step.
 
         Parameters
@@ -124,6 +126,9 @@ class StepConfig:
             Sub step environment configuration to add or update for named sub step.
             If updating this can not have any duplicative leaf keys to the existing
                 sub step environment configuration.
+        sub_step_contine_sub_steps_on_failure : bool
+            True to continue executing other sub steps in current step if this sub step fails.
+            False to fail all step execution if this sub step fails.
 
         Raises
         ------
@@ -149,15 +154,24 @@ class StepConfig:
                 sub_step_name=sub_step_name,
                 sub_step_implementer_name=sub_step_implementer_name,
                 sub_step_config_dict=sub_step_config_dict,
-                sub_step_env_config=sub_step_env_config
+                sub_step_env_config=sub_step_env_config,
+                sub_step_contine_sub_steps_on_failure=sub_step_contine_sub_steps_on_failure
             )
             self.sub_steps.append(sub_step_config)
         else:
-            assert sub_step_implementer_name == sub_step_config.sub_step_implementer_name, \
+            assert sub_step_implementer_name == existing_sub_step_config.sub_step_implementer_name,\
                 f"Step ({self.step_name}) failed to update sub step ({sub_step_name})" + \
                 " with new config due to new sub step implementer" + \
                 f" ({sub_step_implementer_name}) not matching existing sub step implementer" + \
-                f" ({sub_step_config.sub_step_implementer_name})."
+                f" ({existing_sub_step_config.sub_step_implementer_name})."
 
-            sub_step_config.merge_sub_step_config(sub_step_config_dict)
-            sub_step_config.merge_sub_step_env_config(sub_step_env_config)
+            assert sub_step_contine_sub_steps_on_failure == \
+                    existing_sub_step_config.sub_step_contine_sub_steps_on_failure, \
+                f"Step ({self.step_name}) failed to update sub step ({sub_step_name})" + \
+                " with new config due to new continue sub steps on failure" + \
+                f" ({sub_step_contine_sub_steps_on_failure}) not matching existing" + \
+                " continue sub steps on failure " + \
+                f" ({existing_sub_step_config.sub_step_implementer_name})."
+
+            existing_sub_step_config.merge_sub_step_config(sub_step_config_dict)
+            existing_sub_step_config.merge_sub_step_env_config(sub_step_env_config)

--- a/src/ploigos_step_runner/config/sub_step_config.py
+++ b/src/ploigos_step_runner/config/sub_step_config.py
@@ -22,6 +22,9 @@ class SubStepConfig:
         Configuration specific to this sub step.
     sub_step_env_config : dict, optional
         Environment specific configuration specific to this sub step.
+    sub_step_contine_sub_steps_on_failure : bool
+        True to continue executing other sub steps in current step if this sub step fails.
+        False to fail all step execution if this sub step fails.
 
     Attributes
     ----------
@@ -33,16 +36,19 @@ class SubStepConfig:
     """
 
     def __init__( # pylint: disable=too-many-arguments
-            self,
-            parent_step_config,
-            sub_step_name,
-            sub_step_implementer_name,
-            sub_step_config_dict=None,
-            sub_step_env_config=None):
+        self,
+        parent_step_config,
+        sub_step_name,
+        sub_step_implementer_name,
+        sub_step_config_dict=None,
+        sub_step_env_config=None,
+        sub_step_contine_sub_steps_on_failure=False
+    ):
 
         self.__parent_step_config = parent_step_config
         self.__sub_step_name = sub_step_name
         self.__sub_step_implementer_name = sub_step_implementer_name
+        self.__sub_step_contine_sub_steps_on_failure = sub_step_contine_sub_steps_on_failure
 
         if sub_step_config_dict is None:
             sub_step_config_dict = {}
@@ -146,6 +152,19 @@ class SubStepConfig:
             The environment specific configuration for all environments for this sub step.
         """
         return copy.deepcopy(self.__sub_step_env_config)
+
+    @property
+    def sub_step_contine_sub_steps_on_failure(self):
+        """Gets whether to continue executing other sub steps that belong to the step that
+        this sub step belongs to or not if this sub step fails.
+
+        Returns
+        -------
+        bool
+            True to continue executing other sub steps in current step if this sub step fails.
+            False to fail all step execution if this sub step fails.
+        """
+        return self.__sub_step_contine_sub_steps_on_failure
 
     def get_global_environment_defaults(self, env):
         """Convince function for getting the global environment defaults from the parent config.

--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -291,7 +291,7 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
 
         # print information about the configuration
         StepImplementer.__print_section_title(
-            f"Configuration - {self.step_name}",
+            f"Configuration - {self.step_name} - {self.sub_step_name}",
             div_char="-",
             indent=1
         )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,12 +1,11 @@
 import os.path
 
-from testfixtures import TempDirectory
-
-from tests.helpers.base_test_case import BaseTestCase
-
-from ploigos_step_runner.decryption_utils import DecryptionUtils
 from ploigos_step_runner.config import Config, ConfigValue
 from ploigos_step_runner.config.decryptors.sops import SOPS
+from ploigos_step_runner.decryption_utils import DecryptionUtils
+from testfixtures import TempDirectory
+from tests.helpers.base_test_case import BaseTestCase
+
 
 class TestConfig(BaseTestCase):
     def test_add_config_invalid_type(self):
@@ -920,6 +919,102 @@ class TestConfig(BaseTestCase):
             {
                 'test2': 'foo'
             }
+        )
+
+    def test_sub_step_with_continue_sub_steps_on_failure_bool(self):
+        config = Config({
+            Config.CONFIG_KEY: {
+                'step-foo': [
+                    {
+                        'implementer': 'foo1',
+                        'continue-sub-steps-on-failure': True,
+                        'config': {
+                            'test1': 'foo'
+                        }
+                    },
+                    {
+                        'implementer': 'foo2',
+                        'config': {
+                            'test2': 'foo'
+                        }
+                    }
+                ]
+
+            }
+        })
+
+        step_config = config.get_step_config('step-foo')
+        self.assertEqual(len(step_config.sub_steps), 2)
+
+        self.assertEqual(
+            ConfigValue.convert_leaves_to_values(
+                step_config.get_sub_step('foo1').sub_step_config,
+            ),
+            {
+                'test1': 'foo'
+            }
+        )
+        self.assertEqual(
+            ConfigValue.convert_leaves_to_values(
+                step_config.get_sub_step('foo2').sub_step_config
+            ),
+            {
+                'test2': 'foo'
+            }
+        )
+        self.assertTrue(
+            step_config.get_sub_step('foo1').sub_step_contine_sub_steps_on_failure
+        )
+        self.assertFalse(
+            step_config.get_sub_step('foo2').sub_step_contine_sub_steps_on_failure
+        )
+
+    def test_sub_step_with_continue_sub_steps_on_failure_str(self):
+        config = Config({
+            Config.CONFIG_KEY: {
+                'step-foo': [
+                    {
+                        'implementer': 'foo1',
+                        'continue-sub-steps-on-failure': 'true',
+                        'config': {
+                            'test1': 'foo'
+                        }
+                    },
+                    {
+                        'implementer': 'foo2',
+                        'config': {
+                            'test2': 'foo'
+                        }
+                    }
+                ]
+
+            }
+        })
+
+        step_config = config.get_step_config('step-foo')
+        self.assertEqual(len(step_config.sub_steps), 2)
+
+        self.assertEqual(
+            ConfigValue.convert_leaves_to_values(
+                step_config.get_sub_step('foo1').sub_step_config,
+            ),
+            {
+                'test1': 'foo'
+            }
+        )
+        self.assertEqual(
+            ConfigValue.convert_leaves_to_values(
+                step_config.get_sub_step('foo2').sub_step_config
+            ),
+            {
+                'test2': 'foo'
+            }
+        )
+        self.assertTrue(
+            step_config.get_sub_step('foo1').sub_step_contine_sub_steps_on_failure
+        )
+        self.assertFalse(
+            step_config.get_sub_step('foo2').sub_step_contine_sub_steps_on_failure
         )
 
     def test_sub_step_with_name(self):

--- a/tests/helpers/sample_step_implementers.py
+++ b/tests/helpers/sample_step_implementers.py
@@ -30,6 +30,19 @@ class FooStepImplementer(StepImplementer):
         step_result = StepResult.from_step_implementer(self)
         return step_result
 
+class FooStepImplementer2(StepImplementer):
+    @staticmethod
+    def step_implementer_config_defaults():
+        return {}
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        return []
+
+    def _run_step(self):
+        step_result = StepResult.from_step_implementer(self)
+        return step_result
+
 
 class RequiredStepConfigStepImplementer(StepImplementer):
     @staticmethod


### PR DESCRIPTION
# purpose

add an option to allow other sub steps in a step to run even if the given sub step fails. This will still aggregate the failure for the step preventing user override of a step failure.

An example use case is running multiple different container compliance scans against different profiles, even if one fails, want to run them all and aggregate all the results.

# excuses not to do this

Strictly speaking someone could make a workflow with custom named steps like `compliance-scan-stig` and `compliance-scan-cis` and then use the FQDN of the OpenSCAP class to invoke that step implementer in a custom step. BUUUUT its two different control structrues, that is nice if a fixed set of steps controlled by whoever controls the workflow, this approach allows for flexability at the person using a workflow but not so much in that if a single sub step still fails the entire step fails.

# integration testing

* [sample config file](https://github.com/itewk/container-image-scan-pipeline/blob/main/ploigos-step-runner-config/config.yml#L6-L48)
* [sample pipeline run](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Existing%20Container%20Image%20Scan/31/console)