### PR TITLE
include profiles when generating effective pom

### DIFF
--- a/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/maven_generic.py
@@ -189,7 +189,8 @@ class MavenGeneric(StepImplementer):
         if not os.path.exists(effective_pom_path):
             write_effective_pom(
                 pom_file_path=self.get_value('pom-file'),
-                output_path=effective_pom_path
+                output_path=effective_pom_path,
+                profiles=self.get_value('maven-profiles')
             )
 
         return effective_pom_path

--- a/src/ploigos_step_runner/utils/maven.py
+++ b/src/ploigos_step_runner/utils/maven.py
@@ -397,7 +397,8 @@ def add_maven_mirror(
 
 def write_effective_pom(
     pom_file_path,
-    output_path
+    output_path,
+    profiles=None
 ):
     """Generates the effective pom for a given pom and writes it to a given directory
 
@@ -407,6 +408,8 @@ def write_effective_pom(
         Path to pom file to render the effective pom for.
     output_path : str
         Path to write the effective pom to.
+    profiles : list
+        Maven profiles to use when generating the effective pom.
 
     See
     ---
@@ -432,11 +435,16 @@ def write_effective_pom(
             " If you are a user seeing this, a programmer messed up somewhere, report an issue."
         )
 
+    profiles_arguments = ""
+    if profiles:
+        profiles_arguments = ['-P', f"{','.join(profiles)}"]
+
     try:
         sh.mvn( # pylint: disable=no-member
             'help:effective-pom',
             f'-f={pom_file_path}',
-            f'-Doutput={output_path}'
+            f'-Doutput={output_path}',
+            *profiles_arguments
         )
     except sh.ErrorReturnCode as error:
         raise StepRunnerException(

--- a/tests/step_implementers/shared/test_maven_generic.py
+++ b/tests/step_implementers/shared/test_maven_generic.py
@@ -363,7 +363,7 @@ class TestStepImplementerSharedMavenGeneric__get_effective_pom(
 
             # mock effective pom
             Path(pom_file_path).touch()
-            def write_effective_pom_mock_side_effect(pom_file_path, output_path):
+            def write_effective_pom_mock_side_effect(pom_file_path, output_path, profiles):
                 create_parent_dir(pom_file_path)
                 copyfile(pom_file_path, output_path)
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
@@ -377,7 +377,8 @@ class TestStepImplementerSharedMavenGeneric__get_effective_pom(
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
                 pom_file_path=pom_file_path,
-                output_path=expected_effective_pom_path
+                output_path=expected_effective_pom_path,
+                profiles=[]
             )
 
     def test__get_effective_pom_call_twice(self, write_effective_pom_mock):
@@ -396,7 +397,7 @@ class TestStepImplementerSharedMavenGeneric__get_effective_pom(
 
             # mock effective pom
             Path(pom_file_path).touch()
-            def write_effective_pom_mock_side_effect(pom_file_path, output_path):
+            def write_effective_pom_mock_side_effect(pom_file_path, output_path, profiles):
                 create_parent_dir(pom_file_path)
                 copyfile(pom_file_path, output_path)
             write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
@@ -410,7 +411,8 @@ class TestStepImplementerSharedMavenGeneric__get_effective_pom(
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_called_once_with(
                 pom_file_path=pom_file_path,
-                output_path=expected_effective_pom_path
+                output_path=expected_effective_pom_path,
+                profiles=[]
             )
 
             # second call
@@ -422,6 +424,41 @@ class TestStepImplementerSharedMavenGeneric__get_effective_pom(
             actual_effective_pom_path = step_implementer._get_effective_pom()
             self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
             write_effective_pom_mock.assert_not_called()
+
+    def test_call_with_profiles(self, write_effective_pom_mock):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            pom_file_path = os.path.join(test_dir.path, 'pom.xml')
+            step_config = {
+                'pom-file': pom_file_path,
+                'maven-profiles': ['mock-profile1']
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # mock effective pom
+            Path(pom_file_path).touch()
+            def write_effective_pom_mock_side_effect(pom_file_path, output_path, profiles):
+                create_parent_dir(pom_file_path)
+                copyfile(pom_file_path, output_path)
+            write_effective_pom_mock.side_effect = write_effective_pom_mock_side_effect
+
+            # first call
+            expected_effective_pom_path = os.path.join(
+                step_implementer.work_dir_path,
+                'effective-pom.xml'
+            )
+            actual_effective_pom_path = step_implementer._get_effective_pom()
+            self.assertEqual(actual_effective_pom_path, expected_effective_pom_path)
+            write_effective_pom_mock.assert_called_once_with(
+                pom_file_path=pom_file_path,
+                output_path=expected_effective_pom_path,
+                profiles=['mock-profile1']
+            )
 
 @patch('ploigos_step_runner.step_implementers.shared.maven_generic.get_xml_element_by_path')
 @patch.object(MavenGeneric, '_get_effective_pom')

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -986,6 +986,42 @@ class TestMavenUtils(BaseTestCase):
         )
 
     @patch('sh.mvn', create=True)
+    def test_write_effective_pom_with_one_profile(self, mvn_mock):
+        pom_file_path = 'input/pom.xml'
+        effective_pom_path = '/tmp/output/effective-pom.xml'
+
+        actual_effective_pom_path = write_effective_pom(
+            pom_file_path=pom_file_path,
+            output_path=effective_pom_path,
+            profiles=['mock-profile1']
+        )
+        self.assertEqual(actual_effective_pom_path, effective_pom_path)
+        mvn_mock.assert_any_call(
+            'help:effective-pom',
+            f'-f={pom_file_path}',
+            f'-Doutput={effective_pom_path}',
+            '-P', 'mock-profile1'
+        )
+
+    @patch('sh.mvn', create=True)
+    def test_write_effective_pom_with_mutliple_profiles(self, mvn_mock):
+        pom_file_path = 'input/pom.xml'
+        effective_pom_path = '/tmp/output/effective-pom.xml'
+
+        actual_effective_pom_path = write_effective_pom(
+            pom_file_path=pom_file_path,
+            output_path=effective_pom_path,
+            profiles=['mock-profile1', 'mock-profile2']
+        )
+        self.assertEqual(actual_effective_pom_path, effective_pom_path)
+        mvn_mock.assert_any_call(
+            'help:effective-pom',
+            f'-f={pom_file_path}',
+            f'-Doutput={effective_pom_path}',
+            '-P', 'mock-profile1,mock-profile2'
+        )
+
+    @patch('sh.mvn', create=True)
     def test_write_effective_pom_fail(self, mvn_mock):
         pom_file_path = 'input/pom.xml'
         effective_pom_path = '/tmp/output/effective-pom.xml'


### PR DESCRIPTION
# purpose

currently when generating the effective pom the maven profiles are not being included, which they should be in case some important config is enabled by a profile