### PR TITLE
init add create-container-image MavenJKubeK8sBuild

### DIFF
--- a/src/ploigos_step_runner/step_implementers/create_container_image/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/create_container_image/__init__.py
@@ -1,4 +1,7 @@
 """`StepImplementers` for the `create-container-image` step.
 """
 
-from ploigos_step_runner.step_implementers.create_container_image.buildah import Buildah
+from ploigos_step_runner.step_implementers.create_container_image.buildah import \
+    Buildah
+from ploigos_step_runner.step_implementers.create_container_image.maven_jkube_k8sbuild import \
+    MavenJKubeK8sBuild

--- a/src/ploigos_step_runner/utils/containers.py
+++ b/src/ploigos_step_runner/utils/containers.py
@@ -375,3 +375,43 @@ def mount_container(buildah_unshare_command, container_id):
         ) from error
 
     return mount_path
+
+def determine_container_image_build_tag_info(
+    image_version,
+    organization,
+    application_name,
+    service_name
+):
+    """Determines the full and short build tags for a new container image.
+
+    Parameters
+    ----------
+    image_version : str
+        A given image version. If none given, latest will be used.
+    organization : str
+        Organization the container image belongs to.
+    application_name : str
+        Application the container image belongs to.
+    service_name : str
+        Service the container image implements.
+
+    Returns
+    -------
+    str, str, str, str, str
+        First result is the full build tag, including registry URI.
+        Second result is the short build tag, as in no registry URI.
+        Third result is the image registry uri.
+        Forth result is the image repository name.
+        Fifth result is the used image version.
+
+    """
+    if image_version is None:
+        image_version = 'latest'
+        print('No image tag version found in metadata. Using latest')
+    image_registry_uri = 'localhost'
+    image_registry_organization = organization
+    image_repository = f"{application_name}-{service_name}"
+    build_short_tag = f"{image_registry_organization}/{image_repository}:{image_version}"
+    build_full_tag = f"{image_registry_uri}/{build_short_tag}"
+
+    return build_full_tag, build_short_tag, image_registry_uri, image_repository, image_version

--- a/tests/step_implementers/create_container_image/test_maven_jkube_k8sbuild.py
+++ b/tests/step_implementers/create_container_image/test_maven_jkube_k8sbuild.py
@@ -1,0 +1,463 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from ploigos_step_runner import StepResult, StepRunnerException, WorkflowResult
+from ploigos_step_runner.step_implementers.create_container_image import MavenJKubeK8sBuild
+from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+
+
+@patch("ploigos_step_runner.step_implementers.shared.MavenGeneric.__init__")
+class TestStepImplementerMavenJKubeK8sBuild___init__(BaseStepImplementerTestCase):
+    def test_defaults(self, mock_super_init):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = {}
+
+        MavenJKubeK8sBuild(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config
+        )
+
+        mock_super_init.assert_called_once_with(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=None,
+            maven_phases_and_goals=['k8s:build']
+        )
+
+    def test_given_environment(self, mock_super_init):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = {}
+
+        MavenJKubeK8sBuild(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment='mock-env'
+        )
+
+        mock_super_init.assert_called_once_with(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment='mock-env',
+            maven_phases_and_goals=['k8s:build']
+        )
+
+class TestStepImplementerMavenJKubeK8sBuild_step_implementer_config_defaults(
+    BaseStepImplementerTestCase
+):
+    def test_result(self):
+        self.assertEqual(
+            MavenJKubeK8sBuild.step_implementer_config_defaults(),
+            {
+                'pom-file': 'pom.xml',
+                'tls-verify': True,
+                'maven-profiles': [],
+                'maven-additional-arguments': [],
+                'maven-no-transfer-progress': True,
+                'maven-additional-arguments': [
+                    '-Dmaven.install.skip=true',
+                    '-Dmaven.test.skip=true'
+                ]
+            }
+        )
+
+class TestStepImplementerMavenJKubeK8sBuild__required_config_or_result_keys(
+    BaseStepImplementerTestCase
+):
+    def test_result(self):
+        self.assertEqual(
+            MavenJKubeK8sBuild._required_config_or_result_keys(),
+            [
+                'pom-file'
+            ]
+        )
+
+@patch('ploigos_step_runner.step_implementers.create_container_image.maven_jkube_k8sbuild.determine_container_image_build_tag_info')
+@patch.object(MavenJKubeK8sBuild, '_run_maven_step')
+@patch.object(
+    MavenJKubeK8sBuild,
+    'write_working_file',
+    return_value='/mock/mvn_k8s_build_output.txt'
+)
+class TestStepImplementerMavenJKubeK8sBuild__run_step(
+    BaseStepImplementerTestCase
+):
+    def create_step_implementer(
+            self,
+            step_config={},
+            workflow_result=None,
+            parent_work_dir_path=''
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=MavenJKubeK8sBuild,
+            step_config=step_config,
+            step_name='create-container-image',
+            implementer='MavenJKubeK8sBuild',
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+    def test_success_given_version(
+        self,
+        mock_write_working_file,
+        mock_run_maven_step,
+        mock_determine_container_image_build_tag_info
+    ):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            pom_file = os.path.join(test_dir.path, 'mock-pom.xml')
+            step_config = {
+                'pom-file': pom_file,
+                'organization': 'mock-org',
+                'service-name': 'mock-service',
+                'application-name': 'mock-app',
+                'container-image-version': '1.0-123abc'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # setup sideeffects
+            artifact_parent_dir = os.path.join(test_dir.path, 'target')
+            package_artifact_names = [
+                f'my-app.jar'
+            ]
+            def run_maven_side_effect(mvn_output_file_path, step_implementer_additional_arguments):
+                os.makedirs(artifact_parent_dir, exist_ok=True)
+                for artifact_name in package_artifact_names:
+                    artifact_path = os.path.join(
+                        artifact_parent_dir,
+                        artifact_name
+                    )
+                    Path(artifact_path).touch()
+            mock_run_maven_step.side_effect = run_maven_side_effect
+
+            mock_determine_container_image_build_tag_info.return_value=[
+                'localhost/mock-org/mock-app-mock-service:1.0-123abc',
+                'mock-org/mock-app-mock-service:1.0-123abc',
+                'localhost',
+                'mock-app-mock-service',
+                '1.0-123abc'
+            ]
+
+            # run step
+            actual_step_result = step_implementer._run_step()
+
+            # create expected step result
+            expected_step_result = StepResult(
+                step_name='create-container-image',
+                sub_step_name='MavenJKubeK8sBuild',
+                sub_step_implementer_name='MavenJKubeK8sBuild'
+            )
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from running maven to " \
+                    "create container image.",
+                name='maven-jkube-output',
+                value='/mock/mvn_k8s_build_output.txt'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-organization',
+                value='mock-org',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='mock-app-mock-service',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='mock-app-mock-service',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='1.0-123abc',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/mock-org/mock-app-mock-service:1.0-123abc',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='mock-org/mock-app-mock-service:1.0-123abc',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+
+            # verify step result
+            self.assertEqual(
+                actual_step_result,
+                expected_step_result
+            )
+
+            mock_write_working_file.assert_called_once()
+            mock_run_maven_step.assert_called_once_with(
+                mvn_output_file_path='/mock/mvn_k8s_build_output.txt',
+                step_implementer_additional_arguments=[
+                    '-Djkube.generator.name=localhost/mock-org/mock-app-mock-service:1.0-123abc'
+                ]
+            )
+            mock_determine_container_image_build_tag_info.assert_called_once_with(
+                image_version='1.0-123abc',
+                organization='mock-org',
+                application_name='mock-app',
+                service_name='mock-service'
+            )
+
+    def test_success_default_version(
+        self,
+        mock_write_working_file,
+        mock_run_maven_step,
+        mock_determine_container_image_build_tag_info
+    ):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            pom_file = os.path.join(test_dir.path, 'mock-pom.xml')
+            step_config = {
+                'pom-file': pom_file,
+                'organization': 'mock-org',
+                'service-name': 'mock-service',
+                'application-name': 'mock-app'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # setup sideeffects
+            artifact_parent_dir = os.path.join(test_dir.path, 'target')
+            package_artifact_names = [
+                f'my-app.jar'
+            ]
+            def run_maven_side_effect(mvn_output_file_path, step_implementer_additional_arguments):
+                os.makedirs(artifact_parent_dir, exist_ok=True)
+                for artifact_name in package_artifact_names:
+                    artifact_path = os.path.join(
+                        artifact_parent_dir,
+                        artifact_name
+                    )
+                    Path(artifact_path).touch()
+            mock_run_maven_step.side_effect = run_maven_side_effect
+
+            mock_determine_container_image_build_tag_info.return_value=[
+                'localhost/mock-org/mock-app-mock-service:mock-default-version',
+                'mock-org/mock-app-mock-service:mock-default-version',
+                'localhost',
+                'mock-app-mock-service',
+                'mock-default-version'
+            ]
+
+            # run step
+            actual_step_result = step_implementer._run_step()
+
+            # create expected step result
+            expected_step_result = StepResult(
+                step_name='create-container-image',
+                sub_step_name='MavenJKubeK8sBuild',
+                sub_step_implementer_name='MavenJKubeK8sBuild'
+            )
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from running maven to " \
+                    "create container image.",
+                name='maven-jkube-output',
+                value='/mock/mvn_k8s_build_output.txt'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-organization',
+                value='mock-org',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='mock-app-mock-service',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='mock-app-mock-service',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='mock-default-version',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/mock-org/mock-app-mock-service:mock-default-version',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='mock-org/mock-app-mock-service:mock-default-version',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+
+            # verify step result
+            self.assertEqual(
+                actual_step_result,
+                expected_step_result
+            )
+
+            mock_write_working_file.assert_called_once()
+            mock_run_maven_step.assert_called_once_with(
+                mvn_output_file_path='/mock/mvn_k8s_build_output.txt',
+                step_implementer_additional_arguments=[
+                    '-Djkube.generator.name=localhost/mock-org/mock-app-mock-service:mock-default-version'
+                ]
+            )
+            mock_determine_container_image_build_tag_info.assert_called_once_with(
+                image_version=None,
+                organization='mock-org',
+                application_name='mock-app',
+                service_name='mock-service'
+            )
+
+    def test_fail_maven_run(
+        self,
+        mock_write_working_file,
+        mock_run_maven_step,
+        mock_determine_container_image_build_tag_info
+    ):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            pom_file = os.path.join(test_dir.path, 'mock-pom.xml')
+            step_config = {
+                'pom-file': pom_file,
+                'organization': 'mock-org',
+                'service-name': 'mock-service',
+                'application-name': 'mock-app',
+                'container-image-version': '1.0-123abc',
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # set up mocks
+            mock_determine_container_image_build_tag_info.return_value=[
+                'localhost/mock-org/mock-app-mock-service:1.0-123abc',
+                'mock-org/mock-app-mock-service:1.0-123abc',
+                'localhost',
+                'mock-app-mock-service',
+                '1.0-123abc'
+            ]
+
+            # run step with mock failure
+            mock_run_maven_step.side_effect = StepRunnerException('Mock error running maven')
+            actual_step_result = step_implementer._run_step()
+
+            # create expected step result
+            expected_step_result = StepResult(
+                step_name='create-container-image',
+                sub_step_name='MavenJKubeK8sBuild',
+                sub_step_implementer_name='MavenJKubeK8sBuild'
+            )
+            expected_step_result.success = False
+            expected_step_result.message = \
+                "Error running 'maven k8s:build' to create container image. " \
+                "More details maybe found in 'maven-jkube-output' report artifact: " \
+                "Mock error running maven"
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from running maven to " \
+                    "create container image.",
+                name='maven-jkube-output',
+                value='/mock/mvn_k8s_build_output.txt'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-uri',
+                value='localhost',
+                description='Registry URI poriton of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-registry-organization',
+                value='mock-org',
+                description='Organization portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-repository',
+                value='mock-app-mock-service',
+                description='Repository portion of the container image tag' \
+                    ' of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-name',
+                value='mock-app-mock-service',
+                description='Another way to reference the' \
+                    ' repository portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-version',
+                value='1.0-123abc',
+                description='Version portion of the container image tag of the built container image.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-tag',
+                value='localhost/mock-org/mock-app-mock-service:1.0-123abc',
+                description='Full container image tag of the built container,' \
+                    ' including the registry URI.'
+            )
+            expected_step_result.add_artifact(
+                name='container-image-short-tag',
+                value='mock-org/mock-app-mock-service:1.0-123abc',
+                description='Short container image tag of the built container image,' \
+                    ' excluding the registry URI.'
+            )
+
+            # verify step result
+            self.assertEqual(
+                actual_step_result,
+                expected_step_result
+            )
+
+            mock_write_working_file.assert_called_once()
+            mock_run_maven_step.assert_called_once_with(
+                mvn_output_file_path='/mock/mvn_k8s_build_output.txt',
+                step_implementer_additional_arguments=[
+                    '-Djkube.generator.name=localhost/mock-org/mock-app-mock-service:1.0-123abc'
+                ]
+            )
+            mock_determine_container_image_build_tag_info.assert_called_once_with(
+                image_version='1.0-123abc',
+                organization='mock-org',
+                application_name='mock-app',
+                service_name='mock-service'
+            )

--- a/tests/utils/test_containers.py
+++ b/tests/utils/test_containers.py
@@ -1133,3 +1133,66 @@ class Test_mount_container(BaseTestCase):
             _err=Any(IOBase),
             _tee='err'
         )
+
+class Test_determine_container_image_build_tag_info(BaseTestCase):
+    def test_given_image_version(self):
+        actual_build_full_tag, actual_build_short_tag, actual_image_registry_uri, \
+            actual_image_repository, actual_image_version = \
+            determine_container_image_build_tag_info(
+                image_version='1.0-123abc',
+                organization='mock-org',
+                application_name='mock-app',
+                service_name='mock-service'
+            )
+
+        self.assertEqual(
+            actual_build_full_tag,
+            'localhost/mock-org/mock-app-mock-service:1.0-123abc'
+        )
+        self.assertEqual(
+            actual_build_short_tag,
+            'mock-org/mock-app-mock-service:1.0-123abc'
+        )
+        self.assertEqual(
+            actual_image_registry_uri,
+            'localhost'
+        )
+        self.assertEqual(
+            actual_image_repository,
+            'mock-app-mock-service'
+        )
+        self.assertEqual(
+            actual_image_version,
+            '1.0-123abc'
+        )
+
+    def test_default_image_version(self):
+        actual_build_full_tag, actual_build_short_tag, actual_image_registry_uri, \
+            actual_image_repository, actual_image_version = \
+            determine_container_image_build_tag_info(
+                image_version=None,
+                organization='mock-org',
+                application_name='mock-app',
+                service_name='mock-service'
+            )
+
+        self.assertEqual(
+            actual_build_full_tag,
+            'localhost/mock-org/mock-app-mock-service:latest'
+        )
+        self.assertEqual(
+            actual_build_short_tag,
+            'mock-org/mock-app-mock-service:latest'
+        )
+        self.assertEqual(
+            actual_image_registry_uri,
+            'localhost'
+        )
+        self.assertEqual(
+            actual_image_repository,
+            'mock-app-mock-service'
+        )
+        self.assertEqual(
+            actual_image_version,
+            'latest'
+        )


### PR DESCRIPTION
# purpose

Initial add of functionality to use Maven JKube project to do container builds.

# related

- related https://github.com/ploigos/ploigos-charts/pull/19
- related https://github.com/ploigos/ploigos-charts/pull/18
- required for tekton to work - https://github.com/ploigos/ploigos-charts/pull/20

# integration testing

## jenkins

### reference-quarkus-mvn

- [x] [minimum](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-31/1/)
- [x] [typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-quarkus-mvn/view/change-requests/job/PR-31/1/)
- [x] [everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-31/1/)

### reference-spring-boot-mvn-jkube

- [x] [minimum](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-spring-boot-mvn-jkube/job/main/36/console)
- [ ] typical - skipping due to need to do to a Maven UAT refactor
- [ ] everything - skipping due to need to do to a Maven UAT refactor

## tekton

### reference-quarkus-mvn

- skipping since changes are surface level to buildah build, just a shared function for getting container tag, not affected by jenkins v tekton

### reference-spring-boot-mvn-jkube

- [x] [minimum](https://console-openshift-console.apps.tssc.rht-set.com/k8s/ns/tekton-ploigos/tekton.dev~v1beta1~PipelineRun/ref-spring-boot-jkube-min-hello-mwy4zq/)
- [ ] typical - skipping due to need to do to a Maven UAT refactor
- [ ] everything - skipping due to need to do to a Maven UAT refactor