### PR TITLE
Modified generate evidence json structure to omit sub step name

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_evidence/generate_evidence.py
+++ b/src/ploigos_step_runner/step_implementers/generate_evidence/generate_evidence.py
@@ -206,17 +206,14 @@ class GenerateEvidence(StepImplementer):
         #Iterate over all previous step results
         for previous_step_result in self.workflow_result.workflow_list:
             step_name = previous_step_result.step_name
-            sub_step_name = previous_step_result.sub_step_name
             if step_name not in workflow_dict:
                 workflow_dict[step_name] = {}
-            if sub_step_name not in workflow_dict[step_name]:
-                workflow_dict[step_name][sub_step_name] = {}
 
-            workflow_dict[step_name][sub_step_name][attestations_keyword] = {}
+            workflow_dict[step_name][attestations_keyword] = {}
 
             evidence = previous_step_result.evidence
             for piece_of_evidence in evidence.values():
-                workflow_dict[step_name][sub_step_name]\
+                workflow_dict[step_name]\
                 [attestations_keyword][piece_of_evidence.name]\
                  = {
                     'name': piece_of_evidence.name,
@@ -224,7 +221,7 @@ class GenerateEvidence(StepImplementer):
                     'description': piece_of_evidence.description,
                  }
                 if previous_step_result.environment:
-                    workflow_dict[step_name][sub_step_name]\
+                    workflow_dict[step_name]\
                     [attestations_keyword][piece_of_evidence.name]\
                      ['environment'] = previous_step_result.environment
 

--- a/tests/step_implementers/generate_evidence/test_generate_evidence.py
+++ b/tests/step_implementers/generate_evidence/test_generate_evidence.py
@@ -22,21 +22,19 @@ class TestStepImplementerGenerateEvidenceBase(BaseStepImplementerTestCase):
                 'kind': "WorkflowEvidence",
                 'workflow': {
                     'test-step': {
-                        'test-sub-step': {
-                            'attestations': {
-                                'test-evidence': {
-                                    'name': 'test-evidence',
-                                    'value': 'test-value',
-                                    'description': 'test-description'
-                                },
-                                'test-evidence2': {
-                                    'name': 'test-evidence2',
-                                    'value': 'test-value2',
-                                    'description': 'test-description2'
-                                }
+                        'attestations': {
+                            'test-evidence': {
+                                'name': 'test-evidence',
+                                'value': 'test-value',
+                                'description': 'test-description'
+                            },
+                            'test-evidence2': {
+                                'name': 'test-evidence2',
+                                'value': 'test-value2',
+                                'description': 'test-description2'
                             }
                         }
-                    }
+                     }
                 }
             }
 
@@ -45,7 +43,6 @@ class TestStepImplementerGenerateEvidenceBase(BaseStepImplementerTestCase):
         'kind': "WorkflowEvidence",
         'workflow': {
             'test-step': {
-                'test-sub-step': {
                     'attestations': {
                         'test-evidence': {
                             'name': 'test-evidence',
@@ -60,7 +57,6 @@ class TestStepImplementerGenerateEvidenceBase(BaseStepImplementerTestCase):
                             'environment': 'foo'
                         }
                     }
-                }
             }
         }
     }
@@ -71,18 +67,16 @@ class TestStepImplementerGenerateEvidenceBase(BaseStepImplementerTestCase):
     "kind": "WorkflowEvidence",
     "workflow": {
         "test-step": {
-            "test-sub-step": {
-                "attestations": {
-                    "test-evidence": {
-                        "name": "test-evidence",
-                        "value": "test-value",
-                        "description": "test-description"
-                    },
-                    "test-evidence2": {
-                        "name": "test-evidence2",
-                        "value": "test-value2",
-                        "description": "test-description2"
-                    }
+            "attestations": {
+                "test-evidence": {
+                    "name": "test-evidence",
+                    "value": "test-value",
+                    "description": "test-description"
+                },
+                "test-evidence2": {
+                    "name": "test-evidence2",
+                    "value": "test-value2",
+                    "description": "test-description2"
                 }
             }
         }


### PR DESCRIPTION
Sample JSON structure:

```
{
    "apiVersion": "automated-governance/v1alpha1",
    "kind": "WorkflowEvidence",
    "workflow": {
        "test-step": {
            "attestations": {
                "test-evidence": {
                    "name": "test-evidence",
                    "value": "test-value",
                    "description": "test-description"
                },
                "test-evidence2": {
                    "name": "test-evidence2",
                    "value": "test-value2",
                    "description": "test-description2"
                }
            }
        }
    }
}
```