### PR TITLE
Add Commitizen generate-metadata step

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_metadata/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/__init__.py
@@ -1,6 +1,7 @@
 """`StepImplementers` for the `generate-metadata` step.
 """
 
+from ploigos_step_runner.step_implementers.generate_metadata.commitizen import Commitizen
 from ploigos_step_runner.step_implementers.generate_metadata.git import Git
 from ploigos_step_runner.step_implementers.generate_metadata.maven import Maven
 from ploigos_step_runner.step_implementers.generate_metadata.npm import Npm

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/commitizen.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/commitizen.py
@@ -1,0 +1,168 @@
+"""`StepImplementer` for the `generate-metadata` step using Commitizen.
+
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+
+  * static configuration
+  * runtime configuration
+  * previous step results
+
+Configuration Key  | Required? | Default    | Description
+-------------------|-----------|------------|-----------
+`repo-root`        | Yes       | `./`       | Directory path to the Git repo to anaylze tags.
+`cz-json`          | Yes       | `.cz.json` | json file with the commitizen configurataion.
+
+Result Artifacts
+----------------
+Results artifacts output by this step.
+
+Result Artifact Key | Description
+--------------------|------------
+`app-version`       | Value to use for `version` portion of semantic version \
+                      (https://semver.org/). Uses the version from `cz bump` in dry-run mode.
+"""
+
+import json
+import io
+import os
+import re
+import sys
+
+import sh
+
+from git import Repo
+from ploigos_step_runner import StepImplementer, StepResult
+
+DEFAULT_CONFIG = {
+    'cz-json': '.cz.json',
+    'repo-root': './',
+}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+    'cz-json',
+    'repo-root'
+]
+
+class Commitizen(StepImplementer):
+    """
+    StepImplementer for the generate-metadata step for Commitizen.
+    """
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+
+        """
+        return DEFAULT_CONFIG
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    def _validate_required_config_or_previous_step_result_artifact_keys(self):
+        """Validates that the required configuration keys or previous step result artifacts
+        are set and have valid values.
+
+        Validates that:
+        * required configuration is given
+        * given 'cz-json' exists
+
+        Raises
+        ------
+        AssertionError
+            If step configuration or previous step result artifacts have invalid required values
+        """
+        super()._validate_required_config_or_previous_step_result_artifact_keys()
+
+        cz_json_path = self.get_value('cz-json')
+        assert os.path.exists(cz_json_path), \
+            f'cz-json does not exist: {cz_json_path}'
+
+        with open(cz_json_path, 'rb') as cz_json:
+            assert json.loads(cz_json.read()), "cz-json is not valid JSON"
+
+    def _run_step(self):
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+
+        step_result = StepResult.from_step_implementer(self)
+        cz_json_path = self.get_value('cz-json')
+
+        repo_root = self.get_value('repo-root')
+        repo = Repo(repo_root)
+        os.chdir(repo_root)
+
+        with open(cz_json_path, 'rb+') as cz_json:
+            cz_json_contents = json.loads(cz_json.read())
+            cz_json_contents['commitizen']['version'] = self._get_version_tag(repo.tags)
+            cz_json.seek(0)
+            cz_json.truncate(0)
+            cz_json.write(json.dumps(cz_json_contents).encode())
+
+        out = io.StringIO()
+        sh.cz.bump( # pylint: disable=no-member
+            '--dry-run',
+            '--yes',
+            _out=out,
+            _err=sys.stderr,
+            _tee='err'
+        )
+        bump_regex = r'tag to create: (\d+.\d+.\d+)'
+        version = re.findall(bump_regex, out.getvalue(),)[0]
+        step_result.add_artifact(name='app-version', value=version)
+
+        return step_result
+
+    @staticmethod
+    def _get_version_tag(tags):
+        """Gets the latest tag version and updates the json config.
+
+        Returns
+        -------
+        tag_version
+            String representing the latest repo tag version.
+        """
+
+        tag_version = '0.0.0'
+
+        # check for existing repo tags. if no existing repo tag is found then default to version
+        # 0.0.0. if existing repo tags are found then use the latest version tag.
+        for tag in tags:
+            semantic_version = re.match(r'.*(\d+).(\d+).(\d+).*', tag.name)
+            for i, part in enumerate(semantic_version.groups()):
+                tag_version_part = tag_version.split('.')[i]
+                if part > tag_version_part:
+                    tag_version = ".".join(semantic_version.groups())
+                elif part < tag_version_part:
+                    break
+
+        return tag_version

--- a/tests/step_implementers/generate_metadata/test_commitizen_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_commitizen_generate_metadata.py
@@ -1,0 +1,206 @@
+# pylint: disable=missing-module-docstring
+# pylint: disable=missing-class-docstring
+# pylint: disable=missing-function-docstring
+import collections
+import functools
+import json
+import os
+import re
+
+from unittest.mock import Mock, patch
+
+from git import Repo
+from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.generate_metadata import Commitizen
+
+
+class TestStepImplementerCommitizenGenerateMetadata(BaseStepImplementerTestCase):
+    def create_step_implementer(
+            self,
+            step_config={},
+            step_name='',
+            implementer='',
+            workflow_result=None,
+            parent_work_dir_path=''
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=Commitizen,
+            step_config=step_config,
+            step_name=step_name,
+            implementer=implementer,
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+    def test_step_implementer_config_defaults(self):
+        defaults = Commitizen.step_implementer_config_defaults()
+        expected_defaults = {
+            'cz-json': '.cz.json',
+            'repo-root': './'
+        }
+        self.assertEqual(defaults, expected_defaults)
+
+    def test__required_config_or_result_keys(self):
+        required_keys = Commitizen._required_config_or_result_keys()
+        expected_required_keys = ['cz-json', 'repo-root']
+        self.assertEqual(required_keys, expected_required_keys)
+
+    def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
+        with TempDirectory() as temp_dir:
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            temp_dir.write('.cz.json', b'''{
+                "commitizen": {
+                    "bump_message": "build: bump $current_version \\u2192 $new_version [skip-ci]", 
+                    "name": "cz_conventional_commits", 
+                    "tag_format": "$version", 
+                    "update_changelog_on_bump": true
+                }
+            }''')
+            cz_json_file_path = os.path.join(temp_dir.path, '.cz.json')
+
+            step_config = {
+                'cz-json': cz_json_file_path,
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Commitizen',
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+    @patch('ploigos_step_runner.step_implementers.generate_metadata.commitizen.sh')
+    @patch('ploigos_step_runner.step_implementers.generate_metadata.commitizen.Repo')
+    def test_run_step_pass_with_no_existing_tags(self, MockRepo, mock_sh):
+        previous_dir = os.getcwd()
+
+        try:
+            with TempDirectory() as temp_dir:
+                parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+                temp_dir.write('.cz.json', b'''{
+                    "commitizen": {
+                        "bump_message": "build: bump $current_version \\u2192 $new_version [skip-ci]", 
+                        "name": "cz_conventional_commits", 
+                        "tag_format": "$version", 
+                        "update_changelog_on_bump": true
+                    }
+                }''')
+                cz_json_path = os.path.join(temp_dir.path, '.cz.json')
+
+                step_config = {
+                    'cz-json': cz_json_path,
+                    'repo-root': temp_dir.path
+                }
+                step_implementer = self.create_step_implementer(
+                    step_config=step_config,
+                    step_name='generate-metadata',
+                    implementer='Commitizen',
+                    parent_work_dir_path=parent_work_dir_path,
+                )
+
+                mock_sh.cz.bump.side_effect = functools.partial(
+                    self._mock_cz_bump, 
+                    path=os.path.join(temp_dir.path, '.cz.json'),
+                    increment_type='minor'
+                )
+                MockRepo().tags = []
+                result = step_implementer._run_step()
+
+                expected_step_result = StepResult(
+                    step_name='generate-metadata',
+                    sub_step_name='Commitizen',
+                    sub_step_implementer_name='Commitizen'
+                )
+                expected_step_result.success = True
+                expected_step_result.add_artifact(name='app-version', value='0.1.0')
+
+                self.assertEqual(result, expected_step_result)
+        finally:
+            os.chdir(previous_dir)
+
+    @patch('ploigos_step_runner.step_implementers.generate_metadata.commitizen.sh')
+    @patch('ploigos_step_runner.step_implementers.generate_metadata.commitizen.Repo')
+    def test_run_step_pass_with_existing_tags(self, MockRepo, mock_sh):
+        previous_dir = os.getcwd()
+
+        try:
+            with TempDirectory() as temp_dir:
+                parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+                repo = Repo.init(str(temp_dir.path))
+
+                temp_dir.write('.cz.json', b'''{
+                    "commitizen": {
+                        "bump_message": "build: bump $current_version \\u2192 $new_version [skip-ci]", 
+                        "name": "cz_conventional_commits", 
+                        "tag_format": "$version", 
+                        "update_changelog_on_bump": true
+                    }
+                }''')
+                cz_json_path = os.path.join(temp_dir.path, '.cz.json')
+
+                step_config = {
+                    'cz-json': cz_json_path,
+                    'repo-root': temp_dir.path
+                }
+                step_implementer = self.create_step_implementer(
+                    step_config=step_config,
+                    step_name='generate-metadata',
+                    implementer='Commitizen',
+                    parent_work_dir_path=parent_work_dir_path,
+                )
+
+                mock_sh.cz.bump.side_effect = functools.partial(
+                    self._mock_cz_bump, 
+                    path=os.path.join(temp_dir.path, '.cz.json'),
+                    increment_type='minor'
+                )
+                tag = collections.namedtuple('Tag', 'name')
+                MockRepo().tags = [
+                    tag(name='v_0.1.0__'),
+                    tag(name='0.3.0'),
+                    tag(name='version_4.34.0'),
+                    tag(name='5.2.7-prerelease'),
+                    tag(name='v3.142.0-test_abcxyz')
+                ]
+                result = step_implementer._run_step()
+
+                expected_step_result = StepResult(
+                    step_name='generate-metadata',
+                    sub_step_name='Commitizen',
+                    sub_step_implementer_name='Commitizen'
+                )
+                expected_step_result.success = True
+                expected_step_result.add_artifact(name='app-version', value='5.3.0')
+
+                self.assertEqual(result, expected_step_result)
+        finally:
+            os.chdir(previous_dir)
+
+    @staticmethod
+    def _mock_cz_bump(*args, path, increment_type, **kwargs):
+        with open(path, 'r') as cz_json:
+            version = json.loads(cz_json.read())['commitizen']['version']
+            version = re.match(r'(?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)', version).groupdict()
+            
+            if increment_type == 'major':
+                version['major'] = str(int(version['major']) + 1)
+                version['minor'] = '0'
+                version['patch'] = '0'
+
+            if increment_type == 'minor':
+                version['minor'] = str(int(version['minor']) + 1)
+                version['patch'] = '0'
+
+            if increment_type == 'patch':
+                version['patch'] = str(int(version['patch']) + 1)
+
+            kwargs['_out'].write(
+                f'tag to create: {version["major"]}.{version["minor"]}.{version["patch"]}'
+            )


### PR DESCRIPTION
# Purpose

Adding the generate-metadata step implementer for [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.2/) using [Commitizen](https://commitizen-tools.github.io/commitizen/).

This step implementer dynamically generates a semantic version from the current repository tags. The resulting version is saved as the `app-version` artifact for use in the tag-source step.

<!--
Please describe the purpose of this pull request.
If for an enhancment please go beyond just saying "adding fuctionality X" and add a reason/use case for the functionality.
-->

# Breaking?
No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->

Tested locally to ensure the semantic version artifact was created correctly.

<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
