### PR TITLE
argo - remove --retry-limit from argocd.wait call cuz its an invalid flag for that call

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd.py
@@ -1006,7 +1006,6 @@ users:
         try:
             sh.argocd.app.wait(  # pylint: disable=no-member
                 '--timeout', argocd_sync_timeout_seconds,
-                '--retry-limit', argocd_sync_retry_limit,
                 '--health',
                 argocd_app_name,
                 _out=sys.stdout,

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -2742,13 +2742,12 @@ class TestStepImplementerDeployArgoCD__argocd_app_sync(TestStepImplementerDeploy
         )
         argocd_mock.app.wait.assert_called_once_with(
             '--timeout', 120,
-            '--retry-limit', 3,
             '--health',
             'test',
             _out=Any(IOBase),
             _err=Any(IOBase)
         )
-	
+
     @patch('sh.argocd', create=True)
     def test__argocd_app_sync_success_retry(self, argocd_mock):
         ArgoCD._ArgoCD__argocd_app_sync(
@@ -2767,7 +2766,6 @@ class TestStepImplementerDeployArgoCD__argocd_app_sync(TestStepImplementerDeploy
         )
         argocd_mock.app.wait.assert_called_once_with(
             '--timeout', 120,
-            '--retry-limit', 4,
             '--health',
             'test',
             _out=Any(IOBase),
@@ -2842,7 +2840,6 @@ class TestStepImplementerDeployArgoCD__argocd_app_sync(TestStepImplementerDeploy
         )
         argocd_mock.app.wait.assert_called_once_with(
             '--timeout', 120,
-            '--retry-limit', 3,
             '--health',
             'test',
             _out=Any(IOBase),


### PR DESCRIPTION
# Purpose

fix bug where `--retry-limit` flag is being called on `argocd wait` when its not a valid flag.

This snuck in due to accidental adding of this flag after running integration test which happened due to integration testing multiple changes where were then separated into different PRs.

# Breaking?
No

# Integration Testing
Tested against a custom workflow dependent on the `--retry-limit` in the `argocd sync` call.
