### PR TITLE
MavenPackage - add error handling for if can't find artifact dir

### DIFF
--- a/src/ploigos_step_runner/step_implementers/package/maven_package.py
+++ b/src/ploigos_step_runner/step_implementers/package/maven_package.py
@@ -170,6 +170,9 @@ class MavenPackage(MavenGeneric):
                 name='packages',
                 value=packages
             )
+        except FileNotFoundError as error:
+            step_result.success = False
+            step_result.message = f"Error finding artifacts after running maven package: {error}"
         except StepRunnerException as error:
             step_result.success = False
             step_result.message = "Error running 'maven package' to package artifacts. " \


### PR DESCRIPTION
# Purpose
when using the MavenPackage step implmenter, if can't find the files produced by the step (or maybe it failed to produce them or something) then right now we get a hard FileNotFoundError which pails out of the PSR not cleanly. need to catch that error and handle gracefully.

# Breaking?
No

# Integration Testing
ummmmm.....don't worry about it.
