### PR TITLE
deploy/argo - use tag rather then branch for revision so that prod doesn't get updated when updating helm chart values for test both of which currently point at 'main' branch in the argo config

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd.py
@@ -332,7 +332,7 @@ class ArgoCD(StepImplementer):
             ArgoCD.__argocd_app_create_or_update(
                 argocd_app_name=argocd_app_name,
                 repo=deployment_config_repo,
-                revision=deployment_config_repo_branch,
+                revision=deployment_config_repo_tag,
                 path=deployment_config_helm_chart_path,
                 dest_server=deployment_config_destination_cluster_uri,
                 auto_sync=self.get_value('argocd-auto-sync'),

--- a/tests/step_implementers/deploy/test_argocd.py
+++ b/tests/step_implementers/deploy/test_argocd.py
@@ -363,7 +363,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             argocd_app_create_or_update_mock.assert_called_once_with(
                 argocd_app_name='test-app-name',
                 repo=step_config['deployment-config-repo'],
-                revision='feature/test',
+                revision='v0.42.0',
                 path=step_config['deployment-config-helm-chart-path'],
                 dest_server='https://kubernetes.default.svc',
                 auto_sync=True,
@@ -518,7 +518,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             argocd_app_create_or_update_mock.assert_called_once_with(
                 argocd_app_name='test-app-name',
                 repo=step_config['deployment-config-repo'],
-                revision='feature/test',
+                revision='v0.42.0',
                 path=step_config['deployment-config-helm-chart-path'],
                 dest_server='https://kubernetes.default.svc',
                 auto_sync=True,
@@ -673,7 +673,7 @@ class TestStepImplementerDeployArgoCD_run_step(TestStepImplementerDeployArgoCDBa
             argocd_app_create_or_update_mock.assert_called_once_with(
                 argocd_app_name='test-app-name',
                 repo=step_config['deployment-config-repo'],
-                revision='feature/test',
+                revision='v0.42.0',
                 path=step_config['deployment-config-helm-chart-path'],
                 dest_server='https://kubernetes.default.svc',
                 auto_sync=True,


### PR DESCRIPTION
# Purpose

use tag rather then branch for revision so that prod doesn't get updated when updating helm chart values for test both of which currently point at 'main' branch in the argo config

# Breaking?
Sort of.

## Whats Breaking and why?
Using the tag instead of the branch means that for dev workflow you can't just change the branch of the helm chart to test changes there and imediatly see them. you need to run the piepline again, so it will create a new tag. or you need to hand jam argo to the branch rather then the tag. maybe need to make using the branch v tag an option. 

But for now hard coding to the tag because its more important that people arn't accidently deploying to prod.

# Integration Testing
tested this with minimal jenkins workflow in integraiton environment. No need to test all the otyhes as this chagne isn't affected by worfklwo runner or workflow type.
