### PR TITLE
maven - ensure custom repositories are in profile with ID that is activated by default

### DIFF
--- a/src/ploigos_step_runner/utils/maven.py
+++ b/src/ploigos_step_runner/utils/maven.py
@@ -189,6 +189,8 @@ def add_maven_repositories(parent_element, maven_repositories): # pylint: disabl
         * url not specified
     """
 
+    repositories_profile_id = 'custom-repositories'
+
     if maven_repositories is None:
         return
 
@@ -197,10 +199,14 @@ def add_maven_repositories(parent_element, maven_repositories): # pylint: disabl
     profiles_element = ET.Element('profiles')
     parent_element.append(profiles_element)
     profile_element = ET.Element('profile')
+    profile_id_element = ET.Element('id')
+    profile_id_element.text = repositories_profile_id
+    profile_element.append(profile_id_element)
     profiles_element.append(profile_element)
     repositories_element = ET.Element('repositories')
     profile_element.append(repositories_element)
 
+    # add the repositories to new profile
     if isinstance(maven_repositories, dict):
         for maven_repository_key, maven_repository_conf in maven_repositories.items():
             assert 'url' in maven_repository_conf, \
@@ -247,6 +253,13 @@ def add_maven_repositories(parent_element, maven_repositories): # pylint: disabl
                 releases_enabled=releases_enabled,
                 snapshots_enabled=snapshots_enabled
             )
+
+    # active the profile by default
+    active_profiles_element = ET.Element('activeProfiles')
+    parent_element.append(active_profiles_element)
+    custom_active_profile_element = ET.Element('activeProfile')
+    custom_active_profile_element.text = repositories_profile_id
+    active_profiles_element.append(custom_active_profile_element)
 
 def add_maven_repository(
     parent_element,

--- a/tests/utils/test_maven.py
+++ b/tests/utils/test_maven.py
@@ -75,7 +75,7 @@ class TestMavenUtils_other(BaseTestCase):
                 "snapshots": "true"
             }
         ]
-        settings = '''<settings><profiles><profile><repositories><repository><id>repo1</id><url>repo_url1</url><releases><enabled>true</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository></repositories></profile></profiles></settings>'''
+        settings = '''<settings><profiles><profile><id>custom-repositories</id><repositories><repository><id>repo1</id><url>repo_url1</url><releases><enabled>true</enabled></releases><snapshots><enabled>true</enabled></snapshots></repository></repositories></profile></profiles><activeProfiles><activeProfile>custom-repositories</activeProfile></activeProfiles></settings>'''
 
         with TempDirectory() as temp_dir:
             generate_maven_settings(temp_dir.path, None, maven_repositories, None)
@@ -629,7 +629,7 @@ class TestMavenUtils_other(BaseTestCase):
             r"</profiles></settings>"
         )
 
-    def test_add_maven_servers_list(self):
+    def test_add_maven_repositories_list(self):
         root_element = ET.Element('settings')
 
         maven_repositories = [
@@ -654,10 +654,12 @@ class TestMavenUtils_other(BaseTestCase):
 
         self.assertEqual(
             tree_write_out.getvalue().decode(),
-            r"<settings><profiles><profile><repositories>"
+            r"<settings><profiles><profile><id>custom-repositories</id><repositories>"
             r"<repository><id>server-id-1</id><url>url-1</url></repository>"
             r"<repository><id>server-id-2</id><url>url-2</url></repository>"
-            r"</repositories></profile></profiles></settings>"
+            r"</repositories></profile></profiles>"
+            r"<activeProfiles><activeProfile>custom-repositories</activeProfile></activeProfiles>"
+            r"</settings>"
         )
 
     def test_add_maven_servers_dict_with_id_elements(self):
@@ -685,10 +687,12 @@ class TestMavenUtils_other(BaseTestCase):
 
         self.assertEqual(
             tree_write_out.getvalue().decode(),
-            r"<settings><profiles><profile><repositories>"
+            r"<settings><profiles><profile><id>custom-repositories</id><repositories>"
             r"<repository><id>server-id-1</id><url>url-1</url></repository>"
             r"<repository><id>server-id-2</id><url>url-2</url></repository>"
-            r"</repositories></profile></profiles></settings>"
+            r"</repositories></profile></profiles>"
+            r"<activeProfiles><activeProfile>custom-repositories</activeProfile></activeProfiles>"
+            r"</settings>"
         )
 
     def test_add_maven_servers_dict_no_id_elements(self):
@@ -715,10 +719,12 @@ class TestMavenUtils_other(BaseTestCase):
 
         self.assertEqual(
             tree_write_out.getvalue().decode(),
-            r"<settings><profiles><profile><repositories>"
+            r"<settings><profiles><profile><id>custom-repositories</id><repositories>"
             r"<repository><id>use-me-1</id><url>url-1</url></repository>"
             r"<repository><id>server-id-2</id><url>url-2</url></repository>"
-            r"</repositories></profile></profiles></settings>"
+            r"</repositories></profile></profiles>"
+            r"<activeProfiles><activeProfile>custom-repositories</activeProfile></activeProfiles>"
+            r"</settings>"
         )
 
     def test_add_maven_mirror_valid(self):


### PR DESCRIPTION
# Purpose
currently when adding custom maven repositories they are put in a profile with no id that isn't activated (because it doesnt have an id) making it useless to even have them there.

# fix
add an id to the custom profile with the custom repos and activate it by default.

# Breaking?
No

# Integration Testing
tested in integration environment.
