### PR TITLE
StepImplementer#get_value fix precidense so that previous step results have higher precidense then StepImplementer defaults

### DIFF
--- a/tests/helpers/sample_step_implementers.py
+++ b/tests/helpers/sample_step_implementers.py
@@ -43,6 +43,21 @@ class FooStepImplementer2(StepImplementer):
         step_result = StepResult.from_step_implementer(self)
         return step_result
 
+class FooStepImplementerWithDefaults(StepImplementer):
+    @staticmethod
+    def step_implementer_config_defaults():
+        return {
+            'foo-config-1': 'foo-default1',
+            'foo-config-2': 'foo-default2'
+        }
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        return []
+
+    def _run_step(self):
+        step_result = StepResult.from_step_implementer(self)
+        return step_result
 
 class RequiredStepConfigStepImplementer(StepImplementer):
     @staticmethod

--- a/tests/step_implementers/shared/test_rekor_sign_generic.py
+++ b/tests/step_implementers/shared/test_rekor_sign_generic.py
@@ -16,6 +16,11 @@ from ploigos_step_runner.utils.pgp import detach_sign_with_pgp_key
 from ploigos_step_runner.utils.pgp import import_pgp_key
 from ploigos_step_runner.utils.pgp import export_pgp_public_key
 
+class TestStepImplementerSharedRekorSignGeneric_step_implementer_config_defaults(
+    BaseStepImplementerTestCase
+):
+    def test_result(self):
+        self.assertEqual(RekorSignGeneric.step_implementer_config_defaults(),{})
 
 class TestStepImplementerSharedRekorSignGeneric(BaseStepImplementerTestCase):
     TEST_REKOR_ENTRY = {

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -13,7 +13,7 @@ from testfixtures import TempDirectory
 from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
 from tests.helpers.sample_step_implementers import (
-    FailStepImplementer, FooStepImplementer,
+    FailStepImplementer, FooStepImplementer, FooStepImplementerWithDefaults,
     RequiredStepConfigMultipleOptionsStepImplementer,
     WriteConfigAsResultsStepImplementer)
 
@@ -1047,6 +1047,36 @@ class TestStepImplementer_get_value(TestStepImplementer):
                 step.get_value(['old-param-name', 'does-not-exist']),
                 'foo42'
             )
+
+    def test_get_value_result_before_step_implementer_defaults(self):
+        step_config = {
+            'test': 'hello world'
+        }
+
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            artifact_config = {
+                'foo-config-1': {
+                    'description': '',
+                    'value': 'previous step result'
+                },
+            }
+
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step = self.create_given_step_implementer(
+                step_implementer=FooStepImplementerWithDefaults,
+                step_config=step_config,
+                step_name='foo',
+                implementer='FooStepImplementerWithDefaults',
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            self.assertEqual(step.get_value('foo-config-1'), 'previous step result')
+            self.assertEqual(step.get_value('foo-config-2'), 'foo-default2')
+
 
 class TestStepImplementer_validate_required_config_or_previous_step_result_artifact_keys(TestStepImplementer):
     def test__validate_required_config_or_previous_step_result_artifact_keys_mutliple_keys_missing_config(self):


### PR DESCRIPTION
# Purpose
Currently a StepImplementer's defautls has higher precidence when calling #get_value then previous step results making it impossible for a step to get value from a previous step if current step has a default for that value. This was not in the intended behavior.

# Breaking?
Low chance.

## Whats Breaking and why?
There is a chance someone was depending on the bad behavior of the default taking precidense over the previous step result, but if they were, that was bad, and its unlikely.

Risk will be remediated by running through all of our integration tests.

# Integration Testing

## reference-quarkus-mvn
* [x] [Everything](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(everything)%2Freference-quarkus-mvn/detail/PR-57/2/pipeline)
* [x] [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(typical)%2Freference-quarkus-mvn/detail/PR-57/2/pipeline) 
* [x] [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(minimal)%2Freference-quarkus-mvn/detail/PR-57/2/pipeline)

## reference-spring-boot-mvn-jkube
* [x] [Everything](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(everything)%2Freference-spring-boot-mvn-jkube/detail/PR-4/1/pipeline)
* [x] [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(typical)%2Freference-spring-boot-mvn-jkube/detail/PR-4/1/pipeline) 
* [x] [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(minimal)%2Freference-spring-boot-mvn-jkube/detail/PR-4/1/pipeline)

## reference-undertow-mvn-s2i
* [x] [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-undertow-mvn-s2i/view/change-requests/job/PR-1/20/)
  - NOTE: this is the usecase that found this issue
