### PR TITLE
StepImplementer#get_value - priortize any non-default value for any given possible key over any possible keys default

### DIFF
--- a/src/ploigos_step_runner/step_implementer.py
+++ b/src/ploigos_step_runner/step_implementer.py
@@ -433,12 +433,16 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
         else:
             keys = [key]
 
+        # first try to get config value (without defaults) from any of the keys (in order)
+        # NOTE: do this in its own loop so user config values for any given key are always
+        #       prioritized over result values from any of the keys
         for k in keys:
-            # first try to get config value (without defaults)
             config_value = self.get_config_value(k, with_defaults=False)
             if config_value is not None:
                 return config_value
 
+        # second try to get result value from any of the given keys (in order)
+        for k in keys:
             # if not found config value try to get result value specific to current environment
             if self.environment:
                 result_value = self.get_result_value(
@@ -455,7 +459,10 @@ class StepImplementer(ABC):  # pylint: disable=too-many-instance-attributes
             if result_value is not None:
                 return result_value
 
-            # last get config from defaults
+        # last get config from defaults
+        # NOTE: do this in separate loop so none default values are prioritized for all keys
+        #       over any default values for any of the keys
+        for k in keys:
             config_value_default = self.get_config_value(k, with_defaults=True)
             if config_value_default is not None:
                 return config_value_default

--- a/tests/helpers/sample_step_implementers.py
+++ b/tests/helpers/sample_step_implementers.py
@@ -98,6 +98,28 @@ class RequiredStepConfigMultipleOptionsStepImplementer(StepImplementer):
         for n, v in ConfigValue.convert_leaves_to_values(runtime_step_config).items():
             step_result.add_artifact(name=n, value=v)
         return step_result
+
+class RequiredStepConfigMultipleOptionsWithDefaultStepImplementer(StepImplementer):
+    @staticmethod
+    def step_implementer_config_defaults():
+        return {
+            'new-required-key': 'mock-default-value'
+        }
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        return [
+            ['new-required-key', 'old-required-key']
+        ]
+
+    def _run_step(self):
+        step_result = StepResult.from_step_implementer(self)
+        runtime_step_config = self.config.get_copy_of_runtime_step_config(
+            self.environment,
+            self.step_implementer_config_defaults())
+        for n, v in ConfigValue.convert_leaves_to_values(runtime_step_config).items():
+            step_result.add_artifact(name=n, value=v)
+        return step_result
 class WriteConfigAsResultsStepImplementer(StepImplementer):
     @staticmethod
     def step_implementer_config_defaults():

--- a/tests/test_step_implementer.py
+++ b/tests/test_step_implementer.py
@@ -15,6 +15,7 @@ from tests.helpers.base_step_implementer_test_case import \
 from tests.helpers.sample_step_implementers import (
     FailStepImplementer, FooStepImplementer, FooStepImplementerWithDefaults,
     RequiredStepConfigMultipleOptionsStepImplementer,
+    RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
     WriteConfigAsResultsStepImplementer)
 
 
@@ -1077,6 +1078,115 @@ class TestStepImplementer_get_value(TestStepImplementer):
             self.assertEqual(step.get_value('foo-config-1'), 'previous step result')
             self.assertEqual(step.get_value('foo-config-2'), 'foo-default2')
 
+    def test_multiple_options_with_default_no_config(self):
+        step_config = {
+        }
+
+        step = self.create_given_step_implementer(
+            step_implementer=RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
+            step_config=step_config,
+            step_name='foo',
+            implementer='RequiredStepConfigMultipleOptionsWithDefaultStepImplementer'
+        )
+
+        self.assertEqual(
+            step.get_value(['new-required-key', 'old-required-key']),
+            'mock-default-value'
+        )
+
+    def test_multiple_options_with_default_with_new_value_config_given(self):
+        step_config = {
+            'new-required-key': 'mock-given-value-to-new-config'
+        }
+
+        step = self.create_given_step_implementer(
+            step_implementer=RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
+            step_config=step_config,
+            step_name='foo',
+            implementer='RequiredStepConfigMultipleOptionsWithDefaultStepImplementer'
+        )
+
+        self.assertEqual(
+            step.get_value(['new-required-key', 'old-required-key']),
+            'mock-given-value-to-new-config'
+        )
+
+    def test_multiple_options_with_default_with_old_value_config_given(self):
+        step_config = {
+            'old-required-key': 'mock-given-value-to-old-config'
+        }
+
+        step = self.create_given_step_implementer(
+            step_implementer=RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
+            step_config=step_config,
+            step_name='foo',
+            implementer='RequiredStepConfigMultipleOptionsWithDefaultStepImplementer'
+        )
+
+        self.assertEqual(
+            step.get_value(['new-required-key', 'old-required-key']),
+            'mock-given-value-to-old-config'
+        )
+
+    def test_multiple_options_with_default_with_new_value_config_given_with_previous_step_results_for_new_value(self):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            artifact_config = {
+                'new-required-key': {
+                    'description': '',
+                    'value': 'mock previous step result'
+                },
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'new-required-key': 'mock-given-value-to-new-config'
+            }
+
+            step = self.create_given_step_implementer(
+                step_implementer=RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
+                step_config=step_config,
+                step_name='foo',
+                implementer='RequiredStepConfigMultipleOptionsWithDefaultStepImplementer',
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            self.assertEqual(
+                step.get_value(['new-required-key', 'old-required-key']),
+                'mock-given-value-to-new-config'
+            )
+
+    def test_multiple_options_with_default_with_old_value_config_given_with_previous_step_results_for_new_value(self):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            artifact_config = {
+                'new-required-key': {
+                    'description': '',
+                    'value': 'mock previous step result'
+                },
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'old-required-key': 'mock-given-value-to-old-config'
+            }
+
+            step = self.create_given_step_implementer(
+                step_implementer=RequiredStepConfigMultipleOptionsWithDefaultStepImplementer,
+                step_config=step_config,
+                step_name='foo',
+                implementer='RequiredStepConfigMultipleOptionsWithDefaultStepImplementer',
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            self.assertEqual(
+                step.get_value(['new-required-key', 'old-required-key']),
+                'mock-given-value-to-old-config'
+            )
 
 class TestStepImplementer_validate_required_config_or_previous_step_result_artifact_keys(TestStepImplementer):
     def test__validate_required_config_or_previous_step_result_artifact_keys_mutliple_keys_missing_config(self):


### PR DESCRIPTION
# Purpose
Currently when taking advantage of the ability to support multiple config value names for the same value (such as to maintain backwards comparability) if any of the config values have a default  value specified in the StepImplementer#step_implementer_config_defaults function then that default value will take precidence over the value for a config option of one of the lower precedents names. That is not the intended behavior.

Update the `#get_value` function to exahust searching all keys before looking at defaults.

# Breaking?
Very low chance.

## Whats Breaking and why?
If some step implementer or user happened to be realying on this bug it could break them. but its a very small chance indeed  as they would have to be specifying a value for a lower precident config option but then still expecting the default value to be taking precedence and thus ignoring their provided value, which, would be quite silly indeed.

# Integration Testing
* [ ] [Everything]()
* [ ] [Typical]()
* [ ] [Minimal]()
