### PR TITLE
add tox generic and tox unit test step implementer

### DIFF
--- a/src/ploigos_step_runner/step_implementers/shared/tox_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/tox_generic.py
@@ -1,0 +1,187 @@
+"""
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+* static configuration
+* runtime configuration
+* previous step results
+
+Configuration Key            | Required? | Default          | Description
+-----------------------------|-----------|------------------|-----------
+`tox-config`                 | Yes       | `'tox.ini'`      | tox.ini file for reference app.
+`tox-env`                    | Yes       | `None`           | The tox environment to run against.
+`quiet`                      | No        | `True`           | disable quiet mode during execution.
+"""
+
+
+import os
+from ploigos_step_runner import StepResult, StepRunnerException
+from ploigos_step_runner.step_implementer import StepImplementer
+from ploigos_step_runner.utils.tox import run_tox
+
+
+DEFAULT_CONFIG = {
+    'tox-config': 'tox.ini',
+    'quiet': True,
+}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+    'tox-config',
+    'tox-env'
+]
+
+
+class ToxGeneric(StepImplementer):
+    """Abstract parent class for StepImplementers that use tox.
+    """
+
+    def __init__( # pylint: disable=too-many-arguments
+        self,
+        workflow_result,
+        parent_work_dir_path,
+        config,
+        environment=None,
+        tox_env=None
+    ):
+        self.__tox_env = tox_env
+
+        super().__init__(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=environment
+        )
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+        """
+        return DEFAULT_CONFIG
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    def _validate_required_config_or_previous_step_result_artifact_keys(self):
+        """Validates that the required configuration keys or previous step result artifacts
+        are set and have valid values.
+
+        Validates that:
+        * required configuration is given
+        * given 'tox-config' exists
+
+        Raises
+        ------
+        AssertionError
+            If step configuration or previous step result artifacts have invalid required values
+        """
+        super()._validate_required_config_or_previous_step_result_artifact_keys()
+
+        # if tox-config has value verify file exists
+        # If it doesn't have value and is required function will have already failed
+        tox_config = self.get_value('tox-config')
+        if tox_config is not None:
+            assert os.path.exists(tox_config), \
+                f'Given tox config file (tox-config) does not exist: {tox_config}'
+
+    @property
+    def tox_env(self):
+        """Property for getting the tox arguments.
+
+        Returns
+        -------
+        str
+            Tox arguments
+        """
+        tox_env = None
+        if self.__tox_env:
+            tox_env = self.__tox_env
+        else:
+            tox_env = self.get_value('tox-env')
+
+        return tox_env
+
+    def _run_tox_step(
+        self,
+        tox_output_file_path
+    ):
+        """Runs tox using the configuration given to this step runner.
+
+        Parameters
+        ----------
+        tox_output_file_path : str
+            Path to file containing the tox stdout and stderr output.
+        step_implementer_additional_arguments : []
+            Additional arguments hard coded by the step implementer.
+
+        Raises
+        ------
+        StepRunnerException
+            If tox returns a none 0 exit code.
+        """
+
+        tox_env = self.tox_env
+        quiet = self.get_value('quiet')
+
+        if quiet:
+            tox_args = ('-q', '-e', tox_env,)
+        else:
+            tox_args = ('-e', tox_env,)
+
+        run_tox(
+            tox_output_file_path=tox_output_file_path,
+            tox_args=tox_args
+        )
+
+    def _run_step(self):
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+        step_result = StepResult.from_step_implementer(self)
+
+        # package the artifacts
+        tox_output_file_path = self.write_working_file('tox_output.txt')
+        try:
+            # execute tox step (params come from config)
+            self._run_tox_step(
+                tox_output_file_path=tox_output_file_path
+            )
+        except StepRunnerException as error:
+            step_result.success = False
+            step_result.message = "Error running tox. " \
+                f"More details maybe found in 'tox-output' report artifact: {error}"
+        finally:
+            step_result.add_artifact(
+                description="Standard out and standard error from tox.",
+                name='tox-output',
+                value=tox_output_file_path
+            )
+
+        return step_result

--- a/src/ploigos_step_runner/step_implementers/unit_test/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/unit_test/__init__.py
@@ -5,3 +5,4 @@ from ploigos_step_runner.step_implementers.unit_test.maven import Maven
 from ploigos_step_runner.step_implementers.unit_test.maven_test import \
     MavenTest
 from ploigos_step_runner.step_implementers.unit_test.npm_test import NpmTest
+from ploigos_step_runner.step_implementers.unit_test.tox_test import ToxTest

--- a/src/ploigos_step_runner/step_implementers/unit_test/tox_test.py
+++ b/src/ploigos_step_runner/step_implementers/unit_test/tox_test.py
@@ -1,0 +1,67 @@
+"""`StepImplementer` for the `unit-test` step using tox
+"""
+
+from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.shared.tox_generic import ToxGeneric
+from ploigos_step_runner.exceptions import StepRunnerException
+
+
+class ToxTest(ToxGeneric):
+    """`StepImplementer` for the `unit-test` step using tox.
+    """
+
+    def __init__(self, workflow_result, parent_work_dir_path, config, environment):
+        super().__init__(
+            workflow_result,
+            parent_work_dir_path,
+            config,
+            environment=environment,
+            tox_env='test'
+        )
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return []
+
+    def _run_step(self):
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+        step_result = StepResult.from_step_implementer(self)
+
+        tox_output_file_path = self.write_working_file('tox_test_output.txt')
+
+        try:
+            self._run_tox_step(
+                tox_output_file_path=tox_output_file_path
+            )
+
+        except StepRunnerException as error:
+            step_result.message = "Unit test failures. See 'tox-output'" \
+                f" report artifacts for details: {error}"
+            step_result.success = False
+        finally:
+            step_result.add_artifact(
+                description="Standard out and standard error from 'tox test'.",
+                name='tox-output',
+                value=tox_output_file_path
+            )
+
+        return step_result

--- a/src/ploigos_step_runner/utils/tox.py
+++ b/src/ploigos_step_runner/utils/tox.py
@@ -1,0 +1,41 @@
+"""Shared utils for tox operations.
+"""
+import sys
+import sh
+
+from ploigos_step_runner.exceptions import StepRunnerException
+from ploigos_step_runner.utils.io import \
+    create_sh_redirect_to_multiple_streams_fn_callback
+
+def run_tox(tox_output_file_path, tox_args):
+    """
+    Run a tox command
+
+    Paramters
+    ---------
+    tox_output_file_path:
+        String
+    tox_args:
+        Commandline arguments to tox
+    """
+
+    try:
+        with open(tox_output_file_path, 'w', encoding='utf-8') as tox_output_file:
+            out_callback = create_sh_redirect_to_multiple_streams_fn_callback([
+                sys.stdout,
+                tox_output_file
+            ])
+            err_callback = create_sh_redirect_to_multiple_streams_fn_callback([
+                sys.stderr,
+                tox_output_file
+            ])
+
+            sh.tox( # pylint: disable=no-member
+                tox_args,
+                _out=out_callback,
+                _err=err_callback
+            )
+    except sh.ErrorReturnCode as error:
+        raise StepRunnerException(
+            f"Error running tox. {error}"
+        ) from error

--- a/tests/step_implementers/shared/test_tox_generic.py
+++ b/tests/step_implementers/shared/test_tox_generic.py
@@ -1,0 +1,369 @@
+import os
+from pathlib import Path
+# from shutil import copyfile
+from unittest.mock import PropertyMock, patch
+from ploigos_step_runner import StepResult, StepRunnerException, WorkflowResult
+from ploigos_step_runner.config.config import Config
+from ploigos_step_runner.step_implementers.shared.tox_generic import ToxGeneric
+# from ploigos_step_runner.utils.file import create_parent_dir
+from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+
+
+@patch("ploigos_step_runner.StepImplementer.__init__")
+class TestStepImplementerSharedToxGeneric___init__(BaseStepImplementerTestCase):
+
+    def test_no_environment_no_tox_args(self, mock_super_init):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = {}
+
+        step_implementer = ToxGeneric(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config
+        )
+
+        self.assertIsNone(step_implementer._ToxGeneric__tox_env)
+        mock_super_init.assert_called_once_with(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=None
+        )
+
+    def test_with_environment_no_tox_args(self, mock_super_init):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = {}
+
+        step_implementer = ToxGeneric(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment='fake-env'
+        )
+
+        self.assertIsNone(step_implementer._ToxGeneric__tox_env)
+        mock_super_init.assert_called_once_with(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment='fake-env'
+        )
+
+    def test_no_environment_with_tox_args(self, mock_super_init):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = {}
+
+        step_implementer = ToxGeneric(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            tox_env='fake-env'
+        )
+
+        self.assertEqual(
+            step_implementer._ToxGeneric__tox_env,
+            'fake-env'
+        )
+        mock_super_init.assert_called_once_with(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=None
+        )
+
+class TestStepImplementerSharedToxGeneric_step_implementer_config_defaults(
+    BaseStepImplementerTestCase
+):
+    def test_result(self):
+        self.assertEqual(
+            ToxGeneric.step_implementer_config_defaults(),
+            {
+                'tox-config': 'tox.ini',
+                'quiet': True
+            }
+        )
+
+class TestStepImplementerSharedToxGeneric__required_config_or_result_keys(
+    BaseStepImplementerTestCase
+):
+    def test_result(self):
+        self.assertEqual(
+            ToxGeneric._required_config_or_result_keys(),
+            [
+                'tox-config',
+                'tox-env'
+            ]
+        )
+
+class BaseTestStepImplementerSharedToxGeneric(BaseStepImplementerTestCase):
+    def create_step_implementer(
+            self,
+            step_config={},
+            workflow_result=None,
+            parent_work_dir_path=''
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=ToxGeneric,
+            step_config=step_config,
+            step_name='foo',
+            implementer='ToxGeneric',
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+@patch("ploigos_step_runner.StepImplementer._validate_required_config_or_previous_step_result_artifact_keys")
+class TestStepImplementerSharedToxGeneric__validate_required_config_or_previous_step_result_artifact_keys(
+    BaseTestStepImplementerSharedToxGeneric
+):
+    def test_valid(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            tox_config_path = os.path.join(test_dir.path, 'tox.ini')
+            step_config = {
+                'tox-config': tox_config_path,
+                'tox-env': 'fake-env'
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            Path(tox_config_path).touch()
+            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+            mock_super_validate.assert_called_once_with()
+
+    def test_package_file_does_not_exist(self, mock_super_validate):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            tox_config_path = '/does/not/exist/tox.ini'
+            step_config = {
+                'tox-config': tox_config_path,
+                'tox-env': 'fake-env'
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            with self.assertRaisesRegex(
+                AssertionError,
+                rf'Given tox config file \(tox-config\) does not exist: {tox_config_path}'
+            ):
+                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+                mock_super_validate.assert_called_once_with()
+
+class TestStepImplementerSharedToxGeneric_config(
+    BaseTestStepImplementerSharedToxGeneric
+):
+    def test_use_object_property_no_config_value(self):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        config = None
+
+        step_implementer = ToxGeneric(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            tox_env='test'
+        )
+
+        self.assertEqual(
+            step_implementer.tox_env,
+            'test'
+        )
+
+    def test_use_object_property_with_config_value(self):
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        step_config = {
+            'tox-env': 'config-value-fake-env'
+        }
+        config = Config({
+            Config.CONFIG_KEY: {
+                'foo': [
+                    {
+                        'implementer': 'ToxGeneric',
+                        'config': step_config
+                    }
+                ]
+
+            }
+        })
+
+        step_implementer = ToxGeneric(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            tox_env='object-property-fake-env'
+        )
+
+        self.assertEqual(
+            step_implementer.tox_env,
+            'object-property-fake-env'
+        )
+
+    def test_use_configured_tox_args(self):
+        parent_work_dir_path = '/fake/path'
+        step_config = {
+            'tox-env': 'config-value-tox-env'
+        }
+
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            parent_work_dir_path=parent_work_dir_path,
+        )
+
+        self.assertEqual(
+            step_implementer.tox_env,
+            'config-value-tox-env'
+        )
+
+
+
+@patch('ploigos_step_runner.step_implementers.shared.tox_generic.run_tox')
+@patch.object(
+    ToxGeneric,
+    'tox_env',
+    new_callable=PropertyMock,
+    return_value='fake-env'
+)
+class TestStepImplementerSharedToxGeneric__run_tox_step(BaseTestStepImplementerSharedToxGeneric):
+    def test_defaults(self, mock_args, mock_run_tox):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            tox_config_file = os.path.join(test_dir.path, 'tox.ini')
+            step_config = {
+                'tox-config': tox_config_file
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            tox_output_file_path = os.path.join(test_dir.path, 'tox-output.txt')
+            step_implementer._run_tox_step(
+                tox_output_file_path=tox_output_file_path
+            )
+
+            mock_run_tox.assert_called_with(
+                tox_output_file_path=tox_output_file_path,
+                tox_args=('-q', '-e', 'fake-env',)
+            )
+
+    def test_disable_quiet(self, mock_args, mock_run_tox):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            tox_config_file = os.path.join(test_dir.path, 'tox.ini')
+            step_config = {
+                'tox-config': tox_config_file,
+                'quiet': False
+            }
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            tox_output_file_path = os.path.join(test_dir.path, 'tox-output.txt')
+            step_implementer._run_tox_step(
+                tox_output_file_path=tox_output_file_path
+            )
+
+            mock_run_tox.assert_called_with(
+                tox_output_file_path=tox_output_file_path,
+                tox_args=('-e', 'fake-env',)
+            )
+
+
+@patch.object(ToxGeneric, '_run_tox_step')
+@patch.object(ToxGeneric, 'write_working_file', return_value='/mock/tox_output.txt')
+class TestStepImplementerSharedToxGeneric__run_step(
+    BaseTestStepImplementerSharedToxGeneric):
+    def test_success(self, mock_write_working_file, mock_run_tox_step):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            step_config = {}
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # run step
+            actual_step_result = step_implementer._run_step()
+
+            # create expected step result
+            expected_step_result = StepResult(
+                step_name='foo',
+                sub_step_name='ToxGeneric',
+                sub_step_implementer_name='ToxGeneric'
+            )
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from tox.",
+                name='tox-output',
+                value='/mock/tox_output.txt'
+            )
+
+            # verify step result
+            self.assertEqual(
+                actual_step_result,
+                expected_step_result
+            )
+
+            mock_run_tox_step.assert_called_with(
+                tox_output_file_path='/mock/tox_output.txt'
+            )
+
+    def test_fail(self, mock_write_working_file, mock_run_tox_step):
+        with TempDirectory() as test_dir:
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+
+            step_config = {}
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # run step with mock failure
+            mock_run_tox_step.side_effect = StepRunnerException('Mock error running tox')
+            actual_step_result = step_implementer._run_step()
+
+            # create expected step result
+            expected_step_result = StepResult(
+                step_name='foo',
+                sub_step_name='ToxGeneric',
+                sub_step_implementer_name='ToxGeneric'
+            )
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from tox.",
+                name='tox-output',
+                value='/mock/tox_output.txt'
+            )
+            expected_step_result.message = "Error running tox. " \
+                "More details maybe found in 'tox-output' report artifact: "\
+                "Mock error running tox"
+            expected_step_result.success = False
+
+            # verify step result
+            self.assertEqual(
+                actual_step_result,
+                expected_step_result
+            )
+
+            mock_write_working_file.assert_called_once()
+            mock_run_tox_step.assert_called_with(
+                tox_output_file_path='/mock/tox_output.txt'
+            )

--- a/tests/step_implementers/unit_test/test_tox_test.py
+++ b/tests/step_implementers/unit_test/test_tox_test.py
@@ -1,0 +1,76 @@
+import os
+import sh
+from unittest.mock import patch
+from ploigos_step_runner.results import StepResultArtifact
+from ploigos_step_runner.step_implementers.unit_test import ToxTest
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+from tests.helpers.test_utils import Any
+from testfixtures import TempDirectory
+from io import StringIO
+
+
+class TestToxTest__run_step(BaseStepImplementerTestCase):
+    @patch('sh.tox', create=True) # Given a shell command, 'tox'
+    @patch('os.path.exists', side_effect = lambda filename: filename == 'tox.ini') # Given that a file named tox.ini exists
+    def test_run_shell_command(self, os_path_exists_mock, tox_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an ToxTest step implementer
+            tox_test = self.create_given_step_implementer(ToxTest, parent_work_dir_path=working_dir_path)
+
+            # When I run the step
+            tox_test.run_step()
+
+            # Then it should run a shell command, 'tox test'
+            tox_shell_command_mock.assert_any_call(
+                ('-q', '-e', 'test',),
+                _out=Any(StringIO),
+                _err=Any(StringIO)
+            )
+
+    @patch('sh.tox', create=True) # Given a shell command, 'tox'
+    @patch('os.path.exists', side_effect = lambda filename: filename == 'tox.ini') # Given that a file named tox.ini exists
+    def test_success_false_when_shell_command_fails(self, os_path_exists_mock, tox_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given the 'tox' shell command exits with an error code
+            tox_shell_command_mock.side_effect = sh.ErrorReturnCode('tox', b'mock stdout', b'mock error')
+
+            # Given an ToxTest step implementer
+            tox_test = self.create_given_step_implementer(ToxTest, parent_work_dir_path=working_dir_path)
+
+            # When I run the step
+            step_result = tox_test.run_step()
+
+            # Then the StepResult should have success = False
+            self.assertEqual(step_result.success, False)
+
+    @patch('sh.tox', create=True) # Given a shell command, 'tox'
+    @patch('os.path.exists', side_effect = lambda filename: filename == 'tox.ini') # Given that a file named tox.ini exists
+    def test_add_artifact_with_tox_output(self, os_path_exists_mock, tox_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an ToxTest step implementer
+            tox_test = self.create_given_step_implementer(ToxTest, parent_work_dir_path=working_dir_path)
+
+            # When I run the step
+            step_result = tox_test.run_step()
+
+            # Then the StepResult should have an artifact with the tox output:
+            artifact = step_result.get_artifact('tox-output')
+            output_file_path = os.path.join(working_dir_path, 'tox_test_output.txt')
+            self.assertEqual(artifact, StepResultArtifact(
+                name='tox-output',
+                value=output_file_path,
+                description="Standard out and standard error from 'tox test'."
+            ))

--- a/tests/utils/test_tox.py
+++ b/tests/utils/test_tox.py
@@ -1,0 +1,42 @@
+"""Test for tox.py
+
+Test for the utility for tox operations.
+"""
+from unittest.mock import patch, call, mock_open
+from io import StringIO
+
+from ploigos_step_runner import StepRunnerException
+from tests.helpers.base_test_case import BaseTestCase
+from ploigos_step_runner.utils.tox import run_tox
+from tests.helpers.test_utils import Any
+from pytest import raises
+from sh import ErrorReturnCode
+
+class TestToxUtils(BaseTestCase):
+
+    @patch('sh.tox', create=True) # Given a shell command, 'tox'
+    @patch('ploigos_step_runner.utils.io.create_sh_redirect_to_multiple_streams_fn_callback')  # Given a callback that redirects stdio/stderr
+    @patch("builtins.open", new_callable=mock_open) # Given that I can open files
+    def test_run_script_shell_argument(self, mock_open, redirect_callback_mock, tox_shell_command_mock):
+
+        # When I use run_tox() to run 'command with:args'
+        run_tox('/my/output/file', 'mycommand')
+
+        # Then it should run a shell command, `tox command with:args`
+        tox_shell_command_mock.assert_any_call(
+            'mycommand',
+            _out=Any(StringIO),
+            _err=Any(StringIO)
+        )
+
+    @patch('sh.tox', create=True) # Given a shell command, 'tox'
+    @patch('ploigos_step_runner.utils.io.create_sh_redirect_to_multiple_streams_fn_callback')  # Given a callback that redirects stdio/stderr
+    @patch("builtins.open", new_callable=mock_open) # Given that I can open files
+    def test_run_script_nonzero_exit_code(self, mock_open, redirect_callback_mock, tox_shell_command_mock):
+
+        # Given the shell command exits with an error code
+        tox_shell_command_mock.side_effect = ErrorReturnCode('tox', b'mock stdout', b'mock error')
+
+        # When I use run_tox() to run 'mycommand'
+        with raises(StepRunnerException): # Then it should raise an exception
+            run_tox('/my/output/file', 'mycommand')


### PR DESCRIPTION
# NOTE
replaces https://github.com/ploigos/ploigos-step-runner/pull/219 with clean history

# Purpose
Adding python tox generic and python tox unit test step implementer.

# Breaking?
No

# Integration Testing
Tested a local python tox test environment command execution to confirm the tests ran succesfully against the tox.ini configuration file.

* Tox generic makes no assumption about installed packages or commands defined in the tox.ini. It simply calls the target tox environment defined in the `tox_env` configuration parameter and executes the associated .ini config. 
* The tox unit-test step implementer defaults to `test` for the `tox_env` parameter.