### PR TITLE
SemanticVersion and Git cleanup/refactor

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_metadata/semantic_version.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/semantic_version.py
@@ -37,41 +37,57 @@ Could come from:
   * runtime configuration
   * previous step results
 
-Configuration Key | Required? | Default | Description
-------------------|-----------|---------|-----------
-`app-version`     | Yes       |         | Value to use for `version` portion of \
-                                          semantic version (https://semver.org/).
-`pre-release`     | No        |         | Value to use for `pre-release` portion \
-                                          of semantic version (https://semver.org/). \
-`build`           | Yes       |         | Value to use for `build` portion \
-                                          of semantic version (https://semver.org/).
+Configuration Key                     | Required? | Default | Description
+--------------------------------------|-----------|---------|-----------
+`app-version`                         | Yes       |         | Value to use for `version` portion of semantic version (https://semver.org/). \
+                                                              EX: `<app-version>`
+`is-pre-release`                      | Yes       | `False` | If `True` then will add any relevant `pre-release` identifiers to semantic version (https://semver.org/), \
+                                                              such as the branch name. \
+                                                              If `False` then assumed to be a release build and all `pre-release` identifiers will \
+                                                              be ignored from version as per the semantic version spec (https://semver.org/).
+`branch`                              | No        |         | If `is-pre-release` is `True`, value to use for a pre-release name in pre-release poriton of semantic version (https://semver.org/). \
+                                                              EX: `<app-version>-<branch>`
+`workflow-run-num`                    | No        |         | If `is-pre-release` is `True`, value to use for a numeric identifier of the branch `pre-release` identifier if provided. \
+                                                              Also always used in build identifier. \
+                                                              Since this can be included in the pre-release section, it should be incremental as per the sem version spec.
+                                                              EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<sha>.<workflow-run-num>` <br/>\
+                                                              EX (release): `<app-version>+<sha>.<workflow-run-num>`
+`sha`                                 | No        |         | Value to use for sha build identifier in build portion of semantic version. \
+                                                              EX: `<app-version>+<sha>`
+`sha-build-identifier-length`         | No        | 7       | Trim the given `sha` down to this length when including as build identifier in semantic version
+`additional-pre-release-identifiers`  | No        |         | If `is-pre-release` is `True`, additional `pre-release` identifiers to add to semantic version (https://semver.org/). \
+                                                              Ignored if `is-pre-release` is `False. \
+                                                              EX (pre-release): `<app-version>-<branch>.<workflow-run-num>-<additional-pre-release-identifiers>+<sha>.<workflow-run-num>`
+`additional-build-identifiers`        | No        |         | Additional `build` identifiers to add to semantic version (https://semver.org/). \
+                                                              EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<sha>.<workflow-run-num>.<additional-build-identifiers>` <br/>\
+                                                              EX (release): `<app-version>+<sha>.<workflow-run-num>.<additional-build-identifiers>`
 
 Result Artifacts
 ----------------
 Results artifacts output by this step.
 
-Result Artifact Key       | Description
---------------------------|------------
-`version`                 | Constructed semantic version (https://semver.org/).
-`container-image-tag`     | Constructed semantic version (https://semver.org/) without build number\
-                            since container tags don't support + symbol.
-`container-image-version` | DEPRECIATED. See `container-image-tag`.\
-                            Constructed semantic version (https://semver.org/) without build number\
-                            since container tags don't support + symbol.
-"""
+Result Artifact Key            | Description
+-------------------------------|------------
+`version`                      | Full constructured semantic version
+`container-image-tag`          | Constructed semenatic version without build identifier since not compatible with container image tags
+`semantic-version-core`        | Semantic version version core portion
+`semantic-version-pre-release` | Semantic version version pre-release portion
+`semantic-version-build`       | Semantic version version build portion
 
-from ploigos_step_runner import StepImplementer
-from ploigos_step_runner import StepResult
+"""# pylint: disable=line-too-long
+
+import re
+
+from ploigos_step_runner import StepImplementer, StepResult
 
 DEFAULT_CONFIG = {
-    'release-branch': 'master'
+  'is-pre-release': False,
+  'sha-build-identifier-length': 7
 }
 
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
     'app-version',
-    'pre-release',
-    'release-branch',
-    'build'
+    'is-pre-release'
 ]
 
 class SemanticVersion(StepImplementer):  # pylint: disable=too-few-public-methods
@@ -122,39 +138,139 @@ class SemanticVersion(StepImplementer):  # pylint: disable=too-few-public-method
         """
         step_result = StepResult.from_step_implementer(self)
 
-        app_version = None
+        # construct version and image tag
+        version_core = self.get_value('app-version')
+        version = f'{version_core}'
+        image_tag = f'{version_core}'
         pre_release = None
-        build = None
-        release_branch = self.get_value('release-branch')
-        app_version = self.get_value('app-version')
-        pre_release = self.get_value('pre-release')
-        build = self.get_value('build')
-
-        if pre_release == release_branch:
-            version = f'{app_version}+{build}'
-            image_tag = f'{app_version}'
-        else:
-            version = f'{app_version}-{pre_release}+{build}'
-            image_tag = f'{app_version}-{pre_release}'
+        if self.get_value('is-pre-release'):
+            pre_release = self.__get_semantic_version_pre_release()
+            if pre_release:
+                version += f'-{pre_release}'
+                image_tag += f'-{pre_release}'
+            else:
+                # NOTE: maybe at some point we should set some default pre-release value if
+                #       none calculated so that semver reflects that it is a pre-release?
+                pass
+        build = self.__get_semantic_version_build()
+        if build:
+            version += f'+{build}'
 
         # add artifacts
         step_result.add_artifact(
             name='version',
-            value=version
+            value=version,
+            description='Full constructured semantic version'
         )
         step_result.add_artifact(
             name='container-image-tag',
-            value=image_tag
+            value=image_tag,
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
         )
+        step_result.add_artifact(
+            name='semantic-version-core',
+            value=version_core,
+            description='Semantic version version core portion'
+        )
+        if pre_release:
+            step_result.add_artifact(
+                name='semantic-version-pre-release',
+                value=pre_release,
+                description='Semantic version pre-release portion'
+            )
+        if build:
+            step_result.add_artifact(
+                name='semantic-version-build',
+                value=build,
+                description='Semantic version build portion'
+            )
 
         # add evidence
         step_result.add_evidence(
             name='version',
-            value=version
+            value=version,
+            description='Full constructured semantic version'
         )
         step_result.add_evidence(
             name='container-image-tag',
-            value=image_tag
+            value=image_tag,
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
         )
 
         return step_result
+
+    def __get_semantic_version_pre_release(self):
+        """Get the pre-release portion of the semantic version
+
+        Returns
+        -------
+        Pre-release portion of the semantic version.
+        """
+        pre_release = None
+        pre_release_identifiers = []
+
+        # if branch given add as a pre-release identifier
+        branch = self.get_value('branch')
+        if branch:
+            pre_release_regex = re.compile(r"/", re.IGNORECASE)
+            branch_pre_release_identifier = re.sub(pre_release_regex, '-', branch)
+            pre_release_identifiers.append(branch_pre_release_identifier)
+
+        # if workflow run num given ass as  apre-release identifier
+        workflow_run_num = self.get_value('workflow-run-num')
+        if workflow_run_num:
+            pre_release_identifiers.append(workflow_run_num)
+
+        # if additional pre-release identifiers given, add as pre-release identifiers
+        additional_pre_release_identifiers = self.get_value('additional-pre-release-identifiers')
+        if additional_pre_release_identifiers:
+            if isinstance(additional_pre_release_identifiers, list):
+                pre_release_identifiers += additional_pre_release_identifiers
+            else:
+                pre_release_identifiers.append(additional_pre_release_identifiers)
+
+        if pre_release_identifiers:
+            pre_release = '.'.join(pre_release_identifiers)
+
+        return pre_release
+
+    def __get_semantic_version_build(self):
+        """Get the build portion of the semantic version
+
+        Returns
+        -------
+        Build portion of the semantic version.
+        """
+        build = None
+        build_identifiers = []
+
+        # if sha given add as a build identifier
+        sha = self.get_value('sha')
+        if sha:
+            sha_build_identifier = None
+            sha_build_identifier_length = self.get_value('sha-build-identifier-length')
+            if sha_build_identifier_length:
+                sha_build_identifier = str(sha)[:sha_build_identifier_length]
+            else:
+                sha_build_identifier = sha
+            build_identifiers.append(sha_build_identifier)
+
+        # if workflow run num given as a build identifier
+        workflow_run_num = self.get_value('workflow-run-num')
+        if workflow_run_num:
+            build_identifiers.append(str(workflow_run_num))
+
+        # if additional pre-release identifiers given, add as pre-release identifiers
+        additional_build_identifiers = self.get_value('additional-build-identifiers')
+        if additional_build_identifiers:
+            if isinstance(additional_build_identifiers, list):
+                build_identifiers += additional_build_identifiers
+            else:
+                build_identifiers.append(additional_build_identifiers)
+
+        if build_identifiers:
+            build = '.'.join(build_identifiers)
+
+        return build

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -1,18 +1,15 @@
-# pylint: disable=missing-module-docstring
-# pylint: disable=missing-class-docstring
-# pylint: disable=missing-function-docstring
-import os
 
-from git import Repo
+from unittest.mock import PropertyMock, patch
+
+from git import InvalidGitRepositoryError
+from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.generate_metadata import Git
 from testfixtures import TempDirectory
 from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
-from tests.helpers.test_utils import create_git_commit_with_sample_file
-from ploigos_step_runner import StepResult
-from ploigos_step_runner.step_implementers.generate_metadata import Git
 
 
-class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
+class TestStepImplementerGitGenerateMetadataBase(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -30,209 +27,457 @@ class TestStepImplementerGitGenerateMetadata(BaseStepImplementerTestCase):
             parent_work_dir_path=parent_work_dir_path
         )
 
+class TestStepImplementerGitGenerateMetadata_misc(TestStepImplementerGitGenerateMetadataBase):
     def test_step_implementer_config_defaults(self):
         defaults = Git.step_implementer_config_defaults()
         expected_defaults = {
             'repo-root': './',
-            'build-string-length': 7
+            'release-branch-regexes': ['^main$', '^master$']
         }
         self.assertEqual(defaults, expected_defaults)
 
     def test__required_config_or_result_keys(self):
         required_keys = Git._required_config_or_result_keys()
-        expected_required_keys = ['repo-root', 'build-string-length']
+        expected_required_keys = [
+            'repo-root'
+        ]
         self.assertEqual(required_keys, expected_required_keys)
 
-    def test_run_step_pass(self):
+@patch('ploigos_step_runner.step_implementers.generate_metadata.git.Repo')
+class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGenerateMetadataBase):
+    def test_success_release_branch_default_release_branch_regexes(self, mock_repo):
         with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            repo = Repo.init(str(temp_dir.path))
-
-            create_git_commit_with_sample_file(temp_dir, repo)
-
+            # setup
             step_config = {
-                'repo-root': str(temp_dir.path)
+                'repo-root': temp_dir.path
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
+                implementer='Git'
             )
 
-            result = step_implementer._run_step()
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'main'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
-            # cheating because we don't want to fully mock this yet
-            self.assertTrue(result.success, True)
+            # run test
+            actual_step_result = step_implementer._run_step()
 
-    def test_root_dir_is_not_git_repo(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            step_config = {
-                'repo-root': '/'
-            }
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(
-                step_name='generate-metadata',
-                sub_step_name='Git',
-                sub_step_implementer_name='Git'
-            )
-            expected_step_result.success = False
-            expected_step_result.message = 'Given directory (repo_root) is not a Git repository'
-
-            self.assertEqual(result, expected_step_result)
-
-    def test_root_dir_is_bare_git_repo(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            Repo.init(str(temp_dir.path), bare=True)
-
-            step_config = {
-                'repo-root': str(temp_dir.path)
-            }
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(
-                step_name='generate-metadata',
-                sub_step_name='Git',
-                sub_step_implementer_name='Git'
-            )
-            expected_step_result.success = False
-            expected_step_result.message = 'Given directory (repo_root) is a bare Git repository'
-
-            self.assertEqual(result, expected_step_result)
-
-    def test_no_commit_history(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            Repo.init(str(temp_dir.path))
-
-            step_config = {
-                'repo-root': str(temp_dir.path)
-            }
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            result = step_implementer._run_step()
-
+            # verify results
             expected_step_result = StepResult(
                 step_name='generate-metadata',
                 sub_step_name='Git',
                 sub_step_implementer_name='Git'
             )
             expected_step_result.add_artifact(
-                name='pre-release',
-                value='master'
+                name='branch',
+                value='main'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_success_release_branch_custom_release_branch_regexes_list(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'release-branch-regexes': [
+                    '^release/.*$'
+                ]
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'release/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='release/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_success_release_branch_custom_release_branch_regexes_string(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'release-branch-regexes': '^release/.*$'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'release/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='release/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_success_pre_release_branch_default_release_branch_regexes(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='feature/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_success_pre_release_branch_custom_release_branch_regexes_list(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'release-branch-regexes': [
+                    '^release/.*$'
+                ]
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='feature/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_success_pre_release_branch_custom_release_branch_regexes_string(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'release-branch-regexes': '^release/.*$'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='feature/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+
+    def test_success_pre_release_branch_custom_release_branch_regexes_empty(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'release-branch-regexes': None
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='feature/mock1'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_fail_not_a_git_repo(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo.side_effect = InvalidGitRepositoryError()
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
             )
             expected_step_result.success = False
-            expected_step_result.message = 'Given directory (repo_root) is a ' \
-                                           'git branch (git_branch) with no commit history'
+            expected_step_result.message = f'Given repo-root ({temp_dir.path})' \
+                ' is not a Git repository'
 
-            self.assertEqual(result, expected_step_result)
+            self.assertEqual(actual_step_result, expected_step_result)
 
-    def test_git_repo_with_single_commit_on_master(self):
+
+    def test_fail_git_repo_bare(self, mock_repo):
         with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            repo = Repo.init(str(temp_dir.path))
-
-            create_git_commit_with_sample_file(temp_dir, repo)
-
+            # setup
             step_config = {
-                'repo-root': str(temp_dir.path)
+                'repo-root': temp_dir.path
             }
-
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
+                implementer='Git'
             )
 
-            result = step_implementer._run_step()
+            # setup mocks
+            mock_repo().bare = True
 
-            # cheating because we don't want to fully mock this yet
-            self.assertTrue(result.success, True)
+            # run test
+            actual_step_result = step_implementer._run_step()
 
-    def test_git_repo_with_single_commit_on_feature(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            repo = Repo.init(str(temp_dir.path))
-
-            create_git_commit_with_sample_file(temp_dir, repo)
-
-            # checkout a feature branch
-            git_new_branch = repo.create_head('feature/test0')
-            git_new_branch.checkout()
-
-            step_config = {
-                'repo-root': str(temp_dir.path)
-            }
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
+            # verify results
+            expected_step_result = StepResult(
                 step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
             )
-
-            result = step_implementer._run_step()
-
-            # cheating because we don't want to fully mock this yet
-            self.assertEqual(result.get_artifact_value('pre-release'), 'feature_test0')
-            self.assertTrue(result.success, True)
-
-    def test_directory_is_detached(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-            repo = Repo.init(str(temp_dir.path))
-
-            # create commits
-            create_git_commit_with_sample_file(temp_dir, repo, 'test0')
-            create_git_commit_with_sample_file(temp_dir, repo, 'test1')
-
-            # detach head
-            repo.git.checkout('master^')
-
-            step_config = {
-                'repo-root': str(temp_dir.path)
-            }
-
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='Git',
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(step_name='generate-metadata', sub_step_name='Git',
-                                              sub_step_implementer_name='Git')
             expected_step_result.success = False
-            expected_step_result.message = 'Expected a Git branch in given directory (repo_root) ' \
-                                           'but has a detached head'
+            expected_step_result.message = f'Given repo-root ({temp_dir.path})' \
+                ' is not a Git repository'
 
-            self.assertEqual(result, expected_step_result)
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_fail_is_detached(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = True
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.success = False
+            expected_step_result.message = f'Expected a Git branch in given repo_root' \
+                f' ({temp_dir.path}) but has a detached head'
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    def test_fail_no_commit_history(self, mock_repo):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().head.reference.name = 'main'
+            type(mock_repo().head.reference).commit = PropertyMock(side_effect=ValueError)
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value='main'
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.success = False
+            expected_step_result.message =  f'Given repo-root ({temp_dir.path}) is a' \
+                f' git branch (main) with no commit history'
+
+            self.assertEqual(actual_step_result, expected_step_result)

--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -1,5 +1,6 @@
 import os
 
+from mock import patch
 from ploigos_step_runner import StepResult
 from ploigos_step_runner.step_implementers.generate_metadata import \
     SemanticVersion
@@ -8,7 +9,7 @@ from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
 
 
-class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTestCase):
+class TestStepImplementerSemanticVersionGenerateMetadataBase(BaseStepImplementerTestCase):
     def create_step_implementer(
             self,
             step_config={},
@@ -26,10 +27,15 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
             parent_work_dir_path=parent_work_dir_path
         )
 
+class TestStepImplementerSemanticVersionGenerateMetadata_misc(
+    TestStepImplementerSemanticVersionGenerateMetadataBase
+):
+
     def test_step_implementer_config_defaults(self):
         defaults = SemanticVersion.step_implementer_config_defaults()
         expected_defaults = {
-            'release-branch': 'master'
+            'is-pre-release': False,
+            'sha-build-identifier-length': 7
         }
         self.assertEqual(defaults, expected_defaults)
 
@@ -37,82 +43,576 @@ class TestStepImplementerSemanticVersionGenerateMetadata(BaseStepImplementerTest
         required_keys = SemanticVersion._required_config_or_result_keys()
         expected_required_keys = [
             'app-version',
-            'pre-release',
-            'release-branch',
-            'build'
+            'is-pre-release'
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
-    def test_run_step_pass(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+@patch.object(SemanticVersion, '_SemanticVersion__get_semantic_version_pre_release')
+@patch.object(SemanticVersion, '_SemanticVersion__get_semantic_version_build')
+class TestStepImplementerSemanticVersionGenerateMetadata__run_step(
+    TestStepImplementerSemanticVersionGenerateMetadataBase
+):
+    def test_only_app_version(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
 
-            step_config = {}
+        # setup mocks
+        mock_build.return_value = None
+        mock_pre_release.return_value = None
 
-            artifact_config = {
-                'app-version': {'description': '', 'value': '42.1.0'},
-                'pre-release': {'description': '', 'value': 'master'},
-                'build': {'description': '', 'value': 'abc123'}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+        # run test
+        actual_result= step_implementer._run_step()
 
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='SemanticVersion',
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
+            value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
 
-            result = step_implementer._run_step()
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_not_called()
+        mock_build.assert_called_once()
 
-            expected_step_result = StepResult(
-                step_name='generate-metadata',
-                sub_step_name='SemanticVersion',
-                sub_step_implementer_name='SemanticVersion'
-            )
-            expected_step_result.add_artifact(name='version', value='42.1.0+abc123')
-            expected_step_result.add_artifact(name='container-image-tag', value='42.1.0')
+    def test_app_version_and_build(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
 
-            expected_step_result.add_evidence(name='version', value='42.1.0+abc123')
-            expected_step_result.add_evidence(name='container-image-tag', value='42.1.0')
+        # setup mocks
+        mock_build.return_value = 'mock1'
+        mock_pre_release.return_value = None
 
-            self.assertEqual(result, expected_step_result)
+        # run test
+        actual_result= step_implementer._run_step()
 
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1+mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
+            value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-build',
+            value='mock1',
+            description='Semantic version build portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1+mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
 
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_not_called()
+        mock_build.assert_called_once()
 
-    def test_run_step_pass_different_pre_release(self):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+    def test_app_version_and_is_pre_release_with_given_pre_release_identifiers(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1',
+            'is-pre-release': True
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
 
-            step_config = {}
+        # setup mocks
+        mock_build.return_value = None
+        mock_pre_release.return_value = 'feature-mock1'
 
-            artifact_config = {
-                'app-version': {'description': '', 'value': '42.1.0'},
-                'pre-release': {'description': '', 'value': 'feature123'},
-                'build': {'description': '', 'value': 'abc123'}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+        # run test
+        actual_result= step_implementer._run_step()
 
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                step_name='generate-metadata',
-                implementer='SemanticVersion',
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1-feature-mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1-feature-mock1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
+            value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-pre-release',
+            value='feature-mock1',
+            description='Semantic version pre-release portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1-feature-mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1-feature-mock1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
 
-            result = step_implementer._run_step()
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_called_once()
+        mock_build.assert_called_once()
 
-            expected_step_result = StepResult(
-                step_name='generate-metadata',
-                sub_step_name='SemanticVersion',
-                sub_step_implementer_name='SemanticVersion'
-            )
-            expected_step_result.add_artifact(name='version', value='42.1.0-feature123+abc123')
-            expected_step_result.add_artifact(name='container-image-tag', value='42.1.0-feature123')
+    # NOTE: maybe at some point we should set some default pre-release value if
+    #       none calculated so that semver reflects that it is a pre-release?
+    def test_app_version_and_is_pre_release_without_given_pre_release_identifiers(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1',
+            'is-pre-release': True
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
 
-            expected_step_result.add_evidence(name='version', value='42.1.0-feature123+abc123')
-            expected_step_result.add_evidence(name='container-image-tag', value='42.1.0-feature123')
+        # setup mocks
+        mock_build.return_value = None
+        mock_pre_release.return_value = None
 
-            self.assertEqual(result, expected_step_result)
+        # run test
+        actual_result= step_implementer._run_step()
+
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
+            value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
+
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_called_once()
+        mock_build.assert_called_once()
+
+    def test_app_version_and_is_pre_release_with_given_pre_release_identifiers_and_build(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1',
+            'is-pre-release': True
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
+
+        # setup mocks
+        mock_build.return_value = 'mock3'
+        mock_pre_release.return_value = 'feature-mock1'
+
+        # run test
+        actual_result= step_implementer._run_step()
+
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1-feature-mock1+mock3',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1-feature-mock1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
+            value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-pre-release',
+            value='feature-mock1',
+            description='Semantic version pre-release portion'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-build',
+            value='mock3',
+            description='Semantic version build portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1-feature-mock1+mock3',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1-feature-mock1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
+
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_called_once()
+        mock_build.assert_called_once()
+
+class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_pre_release(
+    TestStepImplementerSemanticVersionGenerateMetadataBase
+):
+    def test_empty(self):
+        # setup
+        step_config = {
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, None)
+
+    def test_only_branch(self):
+        # setup
+        step_config = {
+            'branch': 'feature/mock1'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, 'feature-mock1')
+
+    def test_only_workflow_run_num(self):
+        # setup
+        step_config = {
+            'workflow-run-num': '42'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, '42')
+
+    def test_only_additional_pre_release_identifiers_list(self):
+        # setup
+        step_config = {
+            'additional-pre-release-identifiers': [
+                'mock1',
+                'mock2'
+            ]
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, 'mock1.mock2')
+
+    def test_only_additional_pre_release_identifiers_string(self):
+        # setup
+        step_config = {
+            'additional-pre-release-identifiers': 'mock1'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, 'mock1')
+
+    def test_branch_workflow_run_num_additional_pre_release_identifiers(self):
+        # setup
+        step_config = {
+            'branch': 'feature/mock1',
+            'workflow-run-num': '42',
+            'additional-pre-release-identifiers': [
+                'mock1',
+                'mock2'
+            ]
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_pre_release = step_implementer._SemanticVersion__get_semantic_version_pre_release()
+
+        # verify results
+        self.assertEqual(actual_pre_release, 'feature-mock1.42.mock1.mock2')
+
+class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_build(
+    TestStepImplementerSemanticVersionGenerateMetadataBase
+):
+    def test_empty(self):
+        # setup
+        step_config = {
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, None)
+
+    def test_only_sha_default_length(self):
+        # setup
+        step_config = {
+            'sha': 'a1b2c3d4e5f6g7h8i9'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'a1b2c3d')
+
+    def test_only_sha_custom_length(self):
+        # setup
+        step_config = {
+            'sha': 'a1b2c3d4e5f6g7h8i9',
+            'sha-build-identifier-length': 10
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'a1b2c3d4e5')
+
+    def test_only_sha_no_length(self):
+        # setup
+        step_config = {
+            'sha': 'a1b2c3d4e5f6g7h8i9',
+            'sha-build-identifier-length': None
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'a1b2c3d4e5f6g7h8i9')
+
+    def test_only_workflow_run_num(self):
+        # setup
+        step_config = {
+            'workflow-run-num': 42
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, '42')
+
+    def test_only_additional_build_identifiers_list(self):
+        # setup
+        step_config = {
+            'additional-build-identifiers': [
+                'mock3',
+                'mock4'
+            ]
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'mock3.mock4')
+
+    def test_only_additional_build_identifiers_string(self):
+        # setup
+        step_config = {
+            'additional-build-identifiers': 'mock3'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'mock3')
+
+    def test_sha_workflow_run_num_additional_build_identifiers_list(self):
+        # setup
+        step_config = {
+            'sha': 'a1b2c3d4e5f6g7h8i9',
+            'workflow-run-num': 42,
+            'additional-build-identifiers': [
+                'mock3',
+                'mock4'
+            ]
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        # run test
+        actual_build = step_implementer._SemanticVersion__get_semantic_version_build()
+
+        # verify results
+        self.assertEqual(actual_build, 'a1b2c3d.42.mock3.mock4')


### PR DESCRIPTION
# Purpose

The `generate_metadata.Git` and `generate_metadata.Semanticversion` `StepImplementers` were some of the first to be written in the PSR and have not been touched since, even though we have learned a lot for both how to structure the `StepImplementers` and test them.

The real intent of this clean up is to introduce ability to include a workflow run number in the pre-release and/or build identifer section of the SemanticVersion as well as clean up some cases where the SemanticVersion wasn't actually a Semantic Version by the spec, such as using `_` when not valid in semver.

# Breaking?
Yes

## Whats Breaking and why?
API for `generate_metadata.Git` and `generate_metadata.Semanticversion` `StepImplementers` is changing to support more advanced versioning.

* SemanaticVersion
  - add param: is-pre-release
  - add param: branch
  - add param: workflow-run-num
  - add param: sha
  - add param: sha-build-identifier-length
  - add param: additional-pre-release-identifiers
  - add param: additional-build-identifiers
  - remove param: pre-release
  - remove param: build
* Git
  - add artifact: branch
  - add artifact: is-pre-release
  - add artifact: sah
  - remove artifact: pre-release
  - remove artifact: build
  - remove param: build-string-length

# Integration Testing
* [ ] [Everything](TODO)
* [ ] [Typical](TODO)
* [ ] [Minimal](TODO)
