### PR TITLE
generate_metadata.Jenkins - init add

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_metadata/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/__init__.py
@@ -1,8 +1,12 @@
 """`StepImplementers` for the `generate-metadata` step.
 """
 
-from ploigos_step_runner.step_implementers.generate_metadata.commitizen import Commitizen
+from ploigos_step_runner.step_implementers.generate_metadata.commitizen import \
+    Commitizen
 from ploigos_step_runner.step_implementers.generate_metadata.git import Git
+from ploigos_step_runner.step_implementers.generate_metadata.jenkins import \
+    Jenkins
 from ploigos_step_runner.step_implementers.generate_metadata.maven import Maven
 from ploigos_step_runner.step_implementers.generate_metadata.npm import Npm
-from ploigos_step_runner.step_implementers.generate_metadata.semantic_version import SemanticVersion
+from ploigos_step_runner.step_implementers.generate_metadata.semantic_version import \
+    SemanticVersion

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/jenkins.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/jenkins.py
@@ -1,0 +1,90 @@
+"""`StepImplementer` for the `generate-metadata` step to get metadata from Jenkins.
+
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+
+  * static configuration
+  * runtime configuration
+  * previous step results
+
+Configuration Key        | Required? | Default                  | Description
+-------------------------|-----------|--------------------------|-----------
+N/A                      |           |                          |
+
+Result Artifacts
+----------------
+Results artifacts output by this step.
+
+Result Artifact Key | Description
+--------------------|------------
+`workflow-run-num`  | Incremental workflow run number.
+
+"""# pylint: disable=line-too-long
+
+import os
+
+from ploigos_step_runner import StepImplementer, StepResult
+
+DEFAULT_CONFIG = {
+}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+]
+
+class Jenkins(StepImplementer):  # pylint: disable=too-few-public-methods
+    """
+    StepImplementer for the generate-metadata step for Git.
+    """
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+
+        """
+        return DEFAULT_CONFIG
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    def _run_step(self):
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+        step_result = StepResult.from_step_implementer(self)
+
+        step_result.add_artifact(
+            name='workflow-run-num',
+            value=os.environ.get('BUILD_NUMBER'),
+            description='Incremental workflow run number'
+        )
+
+        return step_result

--- a/tests/step_implementers/generate_metadata/test_jenkins_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_jenkins_generate_metadata.py
@@ -1,0 +1,72 @@
+
+
+from mock import patch
+from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.generate_metadata import Jenkins
+from testfixtures import TempDirectory
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+
+
+class TestStepImplementerJenkinsGenerateMetadataBase(BaseStepImplementerTestCase):
+    def create_step_implementer(
+            self,
+            step_config={},
+            step_name='',
+            implementer='',
+            workflow_result=None,
+            parent_work_dir_path=''
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=Jenkins,
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Jenkins',
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+class TestStepImplementerJenkinsGenerateMetadata_misc(TestStepImplementerJenkinsGenerateMetadataBase):
+    def test_step_implementer_config_defaults(self):
+        defaults = Jenkins.step_implementer_config_defaults()
+        expected_defaults = {
+        }
+        self.assertEqual(defaults, expected_defaults)
+
+    def test__required_config_or_result_keys(self):
+        required_keys = Jenkins._required_config_or_result_keys()
+        expected_required_keys = [
+        ]
+        self.assertEqual(required_keys, expected_required_keys)
+
+@patch('os.environ.get')
+class TestStepImplementerJenkinsGenerateMetadata_run_step(TestStepImplementerJenkinsGenerateMetadataBase):
+    def test_success_release_branch_default_release_branch_regexes(self, mock_os_env_get):
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config
+            )
+
+            # setup mocks
+            mock_os_env_get.return_value = '42'
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Jenkins',
+                sub_step_implementer_name='Jenkins'
+            )
+            expected_step_result.add_artifact(
+                name='workflow-run-num',
+                value='42',
+                description='Incremental workflow run number'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)


### PR DESCRIPTION
# Purpose

add a `generate-metadata`  `StepImplementer` for Jenkins.

# Dependencies

This is useless without https://github.com/ploigos/ploigos-step-runner/pull/230 which is what expects the `workflow-run-num` config value.

# Breaking?
No

# Integration Testing
Tested with internal app.
