### PR TITLE
xml utils - fix the way aggregation works

### DIFF
--- a/src/ploigos_step_runner/utils/xml.py
+++ b/src/ploigos_step_runner/utils/xml.py
@@ -221,30 +221,26 @@ def aggregate_xml_element_attribute_values(xml_file_paths, xml_element, attribs)
     #Loop to check if all values aggregated are integers, floats, strings, or a mix
     #of all three.
     for attrib in attribs:
-        only_numerics = False
-        only_floats = False
+        only_ints = True
+        only_floats = True
 
         #Iteration to determine what pattern all values follow.
         if attrib in report_results:
             for value in report_results[attrib]:
-                #isnumeric() returns True if the value contains numbers
-                #but not a decimal point. If this returns
-                #true then continue because the value would be
-                #a valid float anyway
-                if value.isnumeric():
-                    only_numerics = True
-                    only_floats = True
-                else:
-                    only_numerics = False
-                    try:
-                        float(value)
-                        only_floats = True
-                    except ValueError:
-                        only_floats = False
-                        #Break since only_numerics and only_floats are both false
-                        break
+                # check if int
+                try:
+                    int(value)
+                except ValueError:
+                    only_ints = False
 
-            if only_numerics or only_floats:
+                # check if float
+                try:
+                    float(value)
+                except ValueError:
+                    only_floats = False
+
+
+            if only_ints or only_floats:
                 aggregated_value = 0
             else:
                 aggregated_value = []
@@ -252,7 +248,7 @@ def aggregate_xml_element_attribute_values(xml_file_paths, xml_element, attribs)
             #Iteration to aggregate values based on determined pattern.
             for value in report_results[attrib]:
                 #If a value is numeric and can be a float then it is an integer
-                if only_numerics:
+                if only_ints:
                     aggregated_value = int(aggregated_value) + int(value)
                 #If a value is not numeric but can be a float then it is a float
                 elif only_floats:

--- a/tests/utils/files/sample2.xml
+++ b/tests/utils/files/sample2.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" name="org.acme.rest.json.RunCucumberTest" time="1" tests="3" errors="0" skipped="0" failures="0">
+</testsuite>

--- a/tests/utils/files/sample3.xml
+++ b/tests/utils/files/sample3.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd" name="org.acme.rest.json.RunCucumberTest" time="2.42" tests="3" errors="0" skipped="0" failures="0">
+</testsuite>

--- a/tests/utils/test_xml.py
+++ b/tests/utils/test_xml.py
@@ -101,6 +101,33 @@ class TestXMLUtils_other(BaseTestCase):
 
         self.assertEqual(results, expected_results)
 
+    def test_parse_xml_element_for_attributes_multiple_files_float_and_int(self):
+        """Test to get an xml attribute from xml element
+
+        """
+
+        sample_file_paths = [
+            os.path.join(
+                os.path.dirname(__file__),
+                'files',
+                'sample2.xml'
+            ),
+            os.path.join(
+                os.path.dirname(__file__),
+                'files',
+                'sample3.xml'
+            )
+        ]
+
+        element = 'testsuite'
+        attribs = ['time']
+
+        results = aggregate_xml_element_attribute_values(sample_file_paths, element, attribs)
+
+        expected_results = {'time': 3.42}
+
+        self.assertEqual(results, expected_results)
+
     def test_parse_xml_element_for_attributes_multiple_files(self):
         """Test that element attributes are aggregated if multiple files with same element/attributes exist.
 


### PR DESCRIPTION
# Purpose
simplifies the logic with the way xml attribute aagregation works. there was some cases with mix ints and floats that didn't work before.

# Breaking?
No

# Integration Testing
Tested with internal app
