### PR TITLE
deploy - argocd - clean up argo app name better

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
@@ -99,6 +99,10 @@ Configuration Key                       | Required? | Default  | Description
                                                                  pulling container image for deployment.<br/>\
                                                                  If `False` then use container image tag in container image address when \
                                                                  pulling container image for deployment.
+`organization`                          | Yes       |          | Used to build ArgoCD application name.
+`applciation-name`                      | Yes       |          | Used to build ArgoCD application name.
+`service-name`                          | Yes       |          | Used to build ArgoCD application name.
+`branch`                                | Yes       |          | Used to build ArgoCD application name.
 
 Results
 -------
@@ -151,7 +155,11 @@ REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
         'deployment-config-helm-chart-values-file-image-tag-yq-path'
     ],
     'git-email',
-    'git-name'
+    'git-name',
+    'organization',
+    'applciation-name',
+    'service-name',
+    'branch'
 ]
 
 GIT_AUTHENTICATION_CONFIG = {

--- a/tests/step_implementers/deploy/test_argocd_deploy.py
+++ b/tests/step_implementers/deploy/test_argocd_deploy.py
@@ -75,7 +75,11 @@ class TestStepImplementerSharedArgoCDDeploy_Other(TestStepImplementerDeployArgoC
                 'deployment-config-helm-chart-values-file-image-tag-yq-path'
             ],
             'git-email',
-            'git-name'
+            'git-name',
+            'organization',
+            'applciation-name',
+            'service-name',
+            'branch'
         ]
         self.assertEqual(required_keys, expected_required_keys)
         mock_container_deploy_mixin_required_config_or_result_keys.assert_called_once()


### PR DESCRIPTION
# Purpose

currently if user has branch name like `feature/v0.42.0` a bad argo app name will be created with `.` in it. Need to do better job sanatizing names.

# Breaking?
No

# Integration Testing
Naaaah
