### PR TITLE
Add install-first option to NpmTest

### DIFF
--- a/src/ploigos_step_runner/step_implementers/shared/npm_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/npm_generic.py
@@ -150,7 +150,8 @@ class NpmGeneric(StepImplementer):
     def _run_npm_step(
         self,
         npm_output_file_path,
-        step_implementer_additional_envs=None
+        step_implementer_additional_envs=None,
+        npm_args=None,
     ):
         """Runs npm using the configuration given to this step runner.
 
@@ -160,6 +161,8 @@ class NpmGeneric(StepImplementer):
             Path to file containing the npm stdout and stderr output.
         step_implementer_additional_envs : {}
             Additional environment variables injected by the step implementer.
+        npm_args : str
+            Arguments to pass to npm. Defaults to self.npm_args.
 
         Raises
         ------
@@ -167,7 +170,9 @@ class NpmGeneric(StepImplementer):
             If npm returns a non 0 exit code.
         """
 
-        npm_args = self.npm_args
+        if not npm_args:
+            npm_args = self.npm_args
+
         npm_envs = None
 
         if step_implementer_additional_envs:

--- a/src/ploigos_step_runner/step_implementers/unit_test/npm_test.py
+++ b/src/ploigos_step_runner/step_implementers/unit_test/npm_test.py
@@ -47,6 +47,12 @@ class NpmTest(NpmGeneric):
 
         npm_output_file_path = self.write_working_file('npm_test_output.txt')
         try:
+            if self.get_value('install-first'):
+                self._run_npm_step(
+                    npm_output_file_path=npm_output_file_path,
+                    npm_args='install'
+                )
+
             self._run_npm_step(
                 npm_output_file_path=npm_output_file_path
             )

--- a/tests/step_implementers/unit_test/test_npm_test.py
+++ b/tests/step_implementers/unit_test/test_npm_test.py
@@ -77,3 +77,28 @@ class TestNpmTest__run_step(BaseStepImplementerTestCase):
                 value=output_file_path,
                 description="Standard out and standard error from 'npm test'."
             ))
+
+    @patch('sh.npm', create=True) # Given a shell command, 'npm'
+    @patch('os.path.exists', side_effect = lambda filename: filename == 'package.json') # Given that a file named package.json exists
+    def test_run_install_shell_command(self, os_path_exists_mock, npm_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an NpmTest step implementer that is configured to run 'npm install' before running the unit tests
+            npm_test = self.create_given_step_implementer(
+                NpmTest,
+                step_config={'install-first': True},
+                parent_work_dir_path=working_dir_path
+            )
+
+            # When I run the step
+            npm_test.run_step()
+
+            # Then it should run a shell command, 'npm install'
+            npm_shell_command_mock.assert_any_call(
+                'install',
+                _out=Any(StringIO),
+                _err=Any(StringIO)
+            )


### PR DESCRIPTION
# Purpose
Many JavaScript projects use the following workflow:
1. Run `npm install` to download dependencies, including development dependencies like tools for running unit tests.
2. Run `npm test` to run the unit tests.

Our typical workflow has a unit-test step BEFORE the package step. Currently, projects like this can't be used with the typical workflow and the NpmTest step implementer.

This PR adds the `install-first` config parameter to NpmTest, which tells the PSR to run `npm install` immediately before running the unit tests.

# Breaking?
No

# Integration Testing
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
Typical workflow with NPM reference app: https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-nodejs-npm/view/change-requests/job/PR-1/28/console
(The unit tests pass. The pipeline fails after that, but that's okay for now.)
-->
