### PR TITLE
Feature/gen meta git commit

### DIFF
--- a/src/ploigos_step_runner/__init__.py
+++ b/src/ploigos_step_runner/__init__.py
@@ -282,7 +282,7 @@ From least precedence to highest precedence.
       - implementer: Git
         config: {
           # Optional.
-          #repo-root: './'
+          #git-repo-root: './'
 
           # Optional.
           #build-string-length: 7
@@ -668,7 +668,7 @@ From least precedence to highest precedence.
       - implementer: Git
         config: {
           # Optional.
-          #repo-root: './'
+          #git-repo-root: './'
 
           # Optional.
           #build-string-length: 7

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
@@ -21,9 +21,9 @@ Configuration Key             | Required? | Default                  | Descripti
                                                                        If False, will never commit and push any changes. \
                                                                        If 'release' will only commit and push changes when on a release branch. \
                                                                        If 'pre-release' will only commit and push changes on a pre-release branch.
-`git-repo-root`               | Yes       | `.`                      | Directory path to the Git repository to perform git operations on.
+`git-repo-root`               | Yes       | `./`                     | Directory path to the Git repository to perform git operations on.
 `repo-root`                   | No        |                          | Alias for `git-repo-root`.
-`git-url`                     | No        | Git repo root configured origion url \
+`git-url`                     | No        | Git repo root configured origin url \
                                                                      | URL to Git repository to perform Git operations on. \
                                                                        If not given will use Git remote url set in given Git repository root.
 `url`                         | No        |                          | Alias for `git-url`.
@@ -60,12 +60,17 @@ from ploigos_step_runner.step_implementers.shared import GitMixin
 
 
 DEFAULT_CONFIG = {
+    'git-repo-root': './',
     'release-branch-regexes': ['^main$', '^master$'],
     'git-commit-and-push-changes': False
 }
 
-REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
-]
+"""
+Note
+---
+Some required fields inherited from GitMixin (see `_required_config_or_result_keys`)
+"""
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = []
 
 class Git(StepImplementer, GitMixin):  # pylint: disable=too-few-public-methods
     """
@@ -145,6 +150,11 @@ class Git(StepImplementer, GitMixin):  # pylint: disable=too-few-public-methods
         except StepRunnerException as error:
             step_result.success = False
             step_result.message = str(error)
+            return step_result
+
+        if repo.bare:
+            step_result.success = False
+            step_result.message = 'Given git-repo-root is not a Git repository'
             return step_result
 
         # Need to be able to determine the branch name to determine if is a pre-release build or not

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
@@ -9,15 +9,36 @@ Could come from:
   * runtime configuration
   * previous step results
 
-Configuration Key        | Required? | Default                  | Description
--------------------------|-----------|--------------------------|-----------
-`repo-root`              | Yes       | `./`                     | Directory path to the Git repo to generate \
-                                                                  metadata from. Must not be in a detached head state \
-                                                                  so that `pre-release` value can be determined.
-`release-branch-regexes` | No        | `['^main$', '^master$']` | If current git branch matches any of the given regex patterns, \
-                                                                  then this will be considered a release else \
-                                                                  will be considered a pre-release. \
-                                                                  If no patterns given then will be considered a pre-release.
+Configuration Key             | Required? | Default                  | Description
+------------------------------|-----------|--------------------------|-----------
+`release-branch-regexes`      | No        | `['^main$', '^master$']` | If current git branch matches any of the given regex patterns, \
+                                                                       then this will be considered a release else \
+                                                                       will be considered a pre-release. \
+                                                                       If no patterns given then will be considered a pre-release.
+`git-commit-and-push-changes` | No        | `False`                  | When, if ever, to commit and push any changes detected in the repository. \
+                                                                       One of [True, False, 'always', 'release', 'pre-release']. \
+                                                                       If True or 'always' then will always commit and push any changes. \
+                                                                       If False, will never commit and push any changes. \
+                                                                       If 'release' will only commit and push changes when on a release branch. \
+                                                                       If 'pre-release' will only commit and push changes on a pre-release branch.
+`git-repo-root`               | Yes       | `.`                      | Directory path to the Git repository to perform git operations on.
+`repo-root`                   | No        |                          | Alias for `git-repo-root`.
+`git-url`                     | No        | Git repo root configured origion url \
+                                                                     | URL to Git repository to perform Git operations on. \
+                                                                       If not given will use Git remote url set in given Git repository root.
+`url`                         | No        |                          | Alias for `git-url`.
+`git-username`                | No        |                          | Git username to use when connecting with Git remote. \
+                                                                       Will override username in given git url. \
+                                                                       Will override username in Git url in Git repository root remote url. \
+                                                                       Will be ignored if Git repository url is using SSH.
+`git-password`                | No        |                          | Git password to use when connecting with Git remote. \
+                                                                       Will override password in given git url. \
+                                                                       Will override password in Git url in Git repository root remote url. \
+                                                                       Will be ignored if Git repository url is using SSH.
+`git-user-name`               | Maybe     | `Ploigos Robot`          | User name to use when creating Git commits.
+`git-user-email`              | Maybe     | `ploigos-robot`          | User email to use when creating Git commits.
+`git-commit-message`          | Maybe     | `Automated commit of changes during release engineering generate-metadata step` \
+                                                                     | Git commit message to use when/if creating an automated git commit.
 
 Result Artifacts
 ----------------
@@ -29,25 +50,24 @@ Result Artifact Key | Description
 `is-pre-release`    | `True` if this build should be considered a pre-release, \
                       `False` if should be considered a release.
 `sha`               | Current commit sha.
-
 """# pylint: disable=line-too-long
 
 import re
 
-from git import InvalidGitRepositoryError, Repo
+from ploigos_step_runner import (StepImplementer, StepResult,
+                                 StepRunnerException)
+from ploigos_step_runner.step_implementers.shared import GitMixin
 
-from ploigos_step_runner import StepImplementer, StepResult
 
 DEFAULT_CONFIG = {
-    'repo-root': './',
-    'release-branch-regexes': ['^main$', '^master$']
+    'release-branch-regexes': ['^main$', '^master$'],
+    'git-commit-and-push-changes': False
 }
 
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
-    'repo-root'
 ]
 
-class Git(StepImplementer):  # pylint: disable=too-few-public-methods
+class Git(StepImplementer, GitMixin):  # pylint: disable=too-few-public-methods
     """
     StepImplementer for the generate-metadata step for Git.
     """
@@ -66,7 +86,7 @@ class Git(StepImplementer):  # pylint: disable=too-few-public-methods
         These are the lowest precedence configuration values.
 
         """
-        return DEFAULT_CONFIG
+        return {**GitMixin.step_implementer_config_defaults(), **DEFAULT_CONFIG}
 
     @staticmethod
     def _required_config_or_result_keys():
@@ -83,7 +103,30 @@ class Git(StepImplementer):  # pylint: disable=too-few-public-methods
             Array of configuration keys or previous step result artifacts
             that are required before running the step.
         """
-        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS + \
+            GitMixin._required_config_or_result_keys()
+
+    def _validate_required_config_or_previous_step_result_artifact_keys(self):
+        """Validates that the required configuration keys or previous step result artifacts
+        are set and have valid values.
+
+        Validates that:
+        * required configuration is given
+        * given 'pom-file' exists
+
+        Raises
+        ------
+        AssertionError
+            If step configuration or previous step result artifacts have invalid required values
+        """
+        super()._validate_required_config_or_previous_step_result_artifact_keys()
+
+        # validate git-commit-and-push-changes is boolean or valid string option
+        git_commit_and_push_changes = self.get_value('git-commit-and-push-changes')
+        assert isinstance(git_commit_and_push_changes, bool) or \
+            (git_commit_and_push_changes in ['always', 'release', 'pre-release', 'prerelease']), \
+            "Given configuration option (git-commit-and-push-changes)" \
+            " must either be a boolean or one of [always, release, pre-release]."
 
     def _run_step(self):
         """Runs the step implemented by this StepImplementer.
@@ -95,28 +138,24 @@ class Git(StepImplementer):  # pylint: disable=too-few-public-methods
         """
         step_result = StepResult.from_step_implementer(self)
 
-        repo_root = self.get_value('repo-root')
+        # get the git repo
+        repo = None
         try:
-            repo = Repo(repo_root)
-        except InvalidGitRepositoryError:
+            repo = self.git_repo
+        except StepRunnerException as error:
             step_result.success = False
-            step_result.message = f'Given repo-root ({repo_root}) is not a Git repository'
-            return step_result
-
-        if repo.bare:
-            step_result.success = False
-            step_result.message = f'Given repo-root ({repo_root}) is not a Git repository'
+            step_result.message = str(error)
             return step_result
 
         # Need to be able to determine the branch name to determine if is a pre-release build or not
         if repo.head.is_detached:
             step_result.success = False
-            step_result.message = f'Expected a Git branch in given repo_root ({repo_root})' \
+            step_result.message = 'Expected a Git branch in given git repo root' \
                 ' but has a detached head'
             return step_result
 
         # add branch artifact
-        git_branch = repo.head.reference.name
+        git_branch = repo.active_branch.name
         step_result.add_artifact(
             name='branch',
             value=git_branch
@@ -141,6 +180,15 @@ class Git(StepImplementer):  # pylint: disable=too-few-public-methods
             value=is_pre_release
         )
 
+        # commit and push changes
+        if self.__should_commit_changes_and_push(is_pre_release):
+            try:
+                self.commit_changes_and_push()
+            except StepRunnerException as error:
+                step_result.success = False
+                step_result.message = f"Error committing and pushing changes: {error}"
+                return step_result
+
         # add commit sha artifact
         try:
             git_branch_last_commit_sha = str(repo.head.reference.commit)
@@ -150,8 +198,37 @@ class Git(StepImplementer):  # pylint: disable=too-few-public-methods
             )
         except ValueError:
             step_result.success = False
-            step_result.message = f'Given repo-root ({repo_root}) is a' \
-                f' git branch ({git_branch}) with no commit history'
+            step_result.message = f'Given Git repository root is a' \
+                f' git branch ({git_branch}) with no commit history.'
             return step_result
 
         return step_result
+
+    def __should_commit_changes_and_push(self, is_pre_release):
+        """Determine if should commit changes and push.
+
+        Parameters
+        ----------
+        is_pre_release : bool
+            True if is a pre-release, False if Release.
+
+        Returns
+        -------
+        bool
+            True if should commit changes and push, False if not.
+        """
+        should_commit_changes_and_push = False
+        git_commit_and_push_changes = self.get_value('git-commit-and-push-changes')
+        if git_commit_and_push_changes:
+            if isinstance(git_commit_and_push_changes, bool) and git_commit_and_push_changes:
+                should_commit_changes_and_push = True
+            else:
+                git_commit_and_push_changes = git_commit_and_push_changes.lower()
+                if is_pre_release and (
+                    git_commit_and_push_changes in ('always', 'pre-release', 'prerelease') \
+                ):
+                    should_commit_changes_and_push = True
+                elif not is_pre_release and git_commit_and_push_changes in ('always', 'release'):
+                    should_commit_changes_and_push = True
+
+        return should_commit_changes_and_push

--- a/src/ploigos_step_runner/step_implementers/shared/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/shared/__init__.py
@@ -5,6 +5,7 @@ from ploigos_step_runner.step_implementers.shared.argocd_generic import \
     ArgoCDGeneric
 from ploigos_step_runner.step_implementers.shared.container_deploy_mixin import \
     ContainerDeployMixin
+from ploigos_step_runner.step_implementers.shared.git_mixin import GitMixin
 from ploigos_step_runner.step_implementers.shared.maven_generic import \
     MavenGeneric
 from ploigos_step_runner.step_implementers.shared.maven_test_reporting_mixin import \

--- a/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
+++ b/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
@@ -107,7 +107,7 @@ class GitMixin:
                 self.__git_repo = Repo(repo_root)
             except InvalidGitRepositoryError as error:
                 raise StepRunnerException(
-                    f'Given git-repo-root ({repo_root}) is not a Git repository'
+                    f'Given git-repo-root ({repo_root}) is not a Git repository: {error}'
                 ) from error
 
         return self.__git_repo
@@ -128,13 +128,8 @@ class GitMixin:
         if not self.__git_url:
             # get git url from config or current repo remote
             git_url = self.get_value(['git-url', 'url'])
-
             if not git_url:
-                git_url = self.git_repo.remote.url
-
-            # get given git username and pass
-            git_username = self.get_value('git-username')
-            git_password = self.get_value('git-password')
+                git_url = self.git_repo.remote().url
 
             # if git url is ssh, throw error if git username or password given
             # if git url is http|https combine git username and password with git url
@@ -142,6 +137,10 @@ class GitMixin:
             if split_git_url.scheme in ['ssh']:
                 self.__git_url = git_url
             elif split_git_url.scheme in ['http', 'https']:
+                # get given git username and pass
+                git_username = self.get_value('git-username')
+                git_password = self.get_value('git-password')
+
                 # determine git username
                 if split_git_url.username and git_username:
                     print(

--- a/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
+++ b/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
@@ -1,0 +1,337 @@
+"""A mixin class designed to add shared functionality to StepImplementers that interact with Git.
+
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+* static configuration
+* runtime configuration
+* previous step results
+
+Configuration Key    | Required? | Default              | Description
+---------------------|-----------|----------------------|-----------
+`git-repo-root`      | Yes       | `.`                  | Directory path to the Git repository to perform git operations on.
+`repo-root`          | No        |                      | Alias for `git-repo-root`.
+`git-url`            | No        | Git repo root configured origion url \
+                                                        | URL to Git repository to perform Git operations on. \
+                                                          If not given will use Git remote url set in given Git repository root.
+`url`                | No        |                      | Alias for `git-url`.
+`git-username`       | No        |                      | Git username to use when connecting with Git remote. \
+                                                          Will override username in given git url. \
+                                                          Will override username in Git url in Git repository root remote url. \
+                                                          Will be ignored if Git repository url is using SSH.
+`git-password`       | No        |                      | Git password to use when connecting with Git remote. \
+                                                          Will override password in given git url. \
+                                                          Will override password in Git url in Git repository root remote url. \
+                                                          Will be ignored if Git repository url is using SSH.
+`git-user-name`      | Maybe     | `Ploigos Robot`      | User name to use when creating Git commits.
+`git-user-email`     | Maybe     | `ploigos-robot`      | User email to use when creating Git commits.
+`git-commit-message` | Maybe     | `Automated commit of changes during release engineering generate-metadata step` \
+                                                        | Git commit message to use when/if creating an automated git commit.
+"""# pylint: disable=line-too-long
+
+from urllib.parse import urlsplit, urlunsplit
+
+from git import InvalidGitRepositoryError, Repo
+from git.exc import GitCommandError
+from ploigos_step_runner import StepRunnerException
+
+DEFAULT_CONFIG = {
+    'repo-root': './',
+    'git-commit-message': 'Automated commit of changes during release engineering' \
+        ' generate-metadata step',
+    'git-user-name': 'Ploigos Robot',
+    'git-user-email': 'ploigos-robot'
+}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+    'repo-root'
+]
+
+class GitMixin:
+    """A mixin class designed to add shared functionality
+    to StepImplementers that interact with Git.
+    """
+    def __init__(self):
+        self.__git_repo = None
+        self.__git_url = None
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+        """
+        return DEFAULT_CONFIG
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    @property
+    def git_repo(self):
+        """Get the Git repository.
+
+        Returns
+        -------
+        Repo
+            Git repository object for the given git repository root.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+        """
+        if not self.__git_repo:
+            repo_root = self.get_value(['git-repo-root', 'repo-root'])
+            try:
+                self.__git_repo = Repo(repo_root)
+            except InvalidGitRepositoryError as error:
+                raise StepRunnerException(
+                    f'Given repo-root ({repo_root}) is not a Git repository'
+                ) from error
+
+        return self.__git_repo
+
+    @property
+    def git_url(self): # pylint: disable=too-many-branches
+        """Get the Git url including auth if given.
+
+        This function tries to be smart and combine given username/password into given URL
+        and/or with username/password/url determined from Git repository remote configuration.
+
+        Raises
+        ------
+        StepRunnerException
+            If Git username given but Git url uses SSH
+            If Git password given but Git url uses SSH
+        """
+        if not self.__git_url:
+            # get git url from config or current repo remote
+            git_url = self.get_value(['git-url', 'url'])
+            if not git_url:
+                git_url = self.git_repo.remote().url
+
+            # get given git username and pass
+            git_username = self.get_value('git-username')
+            git_password = self.get_value('git-password')
+
+            # if git url is ssh, throw error if git username or password given
+            # if git url is http|https combine git username and password with git url
+            split_git_url = urlsplit(git_url)
+            if split_git_url.scheme in ['ssh']:
+                if git_username:
+                    raise StepRunnerException(
+                        f"Git username ({git_username}) given but git URL ({git_url}) uses SSH."
+                    )
+                if git_password:
+                    raise StepRunnerException(
+                        f"Git password ({git_password}) given but git URL ({git_url}) uses SSH."
+                    )
+
+                self.__git_url = git_url
+            elif split_git_url.scheme in ['http', 'https']:
+                # determine git username
+                if split_git_url.username and git_username:
+                    print(
+                        f"WARNING: Git url ({git_url}) includes username ({split_git_url.username})"
+                        f" but was given Git username ({git_username})."
+                        f" Will use given Git username ({git_username})."
+                    )
+                elif split_git_url.username:
+                    git_username = split_git_url.username
+
+                # determine git password
+                if split_git_url.password and git_password:
+                    print(
+                        f"WARNING: Git url ({git_url}) includes password ({split_git_url.password})"
+                        f" but was given Git password ({git_password})."
+                        f" Will use given Git password ({git_password})."
+                    )
+                elif split_git_url.password:
+                    git_password = split_git_url.password
+
+                # construct new git url with auth
+                git_netloc = None
+                if git_username and git_password:
+                    git_netloc = f"{git_username}:{git_password}@{split_git_url.hostname}"
+                elif git_username:
+                    git_netloc = f"{git_username}@{split_git_url.hostname}"
+                else:
+                    git_netloc = split_git_url.hostname
+
+                if split_git_url.port:
+                    git_netloc += f":{split_git_url.port}"
+
+                self.__git_url = urlunsplit((
+                    split_git_url.scheme,
+                    git_netloc,
+                    split_git_url.path,
+                    split_git_url.query,
+                    split_git_url.fragment
+                ))
+
+        return self.__git_url
+
+    def configure_git_user(self):
+        """Configures the git user.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+        """
+        repo = self.git_repo
+        repo.config_writer().set_value(
+            "user",
+            "name",
+            self.get_value('git-user-name')
+        ).release()
+        repo.config_writer().set_value(
+            "user",
+            "email",
+            self.get_value('git-user-email')
+        ).release()
+
+    def git_commit_changes(self):
+        """Stages and commits any and all unstaged changes in the Git repository.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+            If error commiting changes to current branch.
+        """
+        repo = self.git_repo
+        try:
+            repo.git.commit('-am', self.get_value('git-commit-message'))
+        except (GitCommandError, Exception) as error:
+            raise StepRunnerException(
+                f"Error committing changes to current branch ({repo.active_branch.name})"
+                f": {error}"
+            ) from error
+
+    def git_push(self):
+        """Push all committed Git changes.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+            If error pushing changes to remote.
+        """
+        repo = self.git_repo
+        try:
+            # NOTE:
+            #   using repo.git.push rather then repo.remote().push() because need to be
+            #   able to override the git url for the push
+            repo.git.push(self.git_url)
+        except (GitCommandError, Exception) as error:
+            raise StepRunnerException(
+                f"Error pushing changes to remote ({self.git_url})"
+                f" on current branch ({repo.active_branch.name}): {error}"
+            ) from error
+
+    def git_push_tags(self):
+        """Push Git tags.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+            If error pushing tags to remote.
+        """
+        repo = self.git_repo
+        try:
+            # NOTE:
+            #   using repo.git.push rather then repo.remote().push() because need to be
+            #   able to override the git url for the push
+            repo.git.push(self.git_url, '--tag')
+        except (GitCommandError, Exception) as error:
+            raise StepRunnerException(
+                f"Error pushing tags to remote ({self.git_url})"
+                f" on current branch ({repo.active_branch.name}): {error}"
+            ) from error
+
+    def commit_changes_and_push(self):
+        """Commits all changes in the given repo and pushes them to the current remote on the
+        current branch. If no changes to commit this is a no-op.
+
+        Parameters
+        ----------
+        repo : git.Repo
+            Repo to commit and push changes to.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+            If error commiting changes to current branch.
+            If error pushing changes to remote.
+
+        """
+        repo = self.git_repo
+        print(
+            f"Commit all changes and push to current remote ({repo.remote().url})" \
+            f" on current branch ({repo.active_branch.name})"
+        )
+
+        if repo.is_dirty():
+            # configure git user
+            self.configure_git_user()
+
+            # commit changes
+            self.git_commit_changes()
+
+            # push changes
+            self.git_push()
+        else:
+            print("No changes to commit and push")
+
+
+    def git_tag(self, git_tag_value):
+        """Create a git tag.
+
+        Parameters
+        ----------
+        git_tag_value : str
+            Value to tag Git repository with.
+
+        Raises
+        ------
+        StepRunnerException
+            If given git repo root is not a Git repository.
+            If error creating Git tag.
+        """
+        try:
+            # NOTE:
+            #   this force is only needed locally in case of a re-run of the same pipeline
+            #   without a fresh check out. You will notice there is no force on the push
+            #   making this an acceptable work around to the issue since on the off chance
+            #   actually overwriting a tag with a different comment, the push will fail
+            #   because the tag will be attached to a different git hash.
+            self.git_repo.create_tag(git_tag_value, force=True)
+        except (GitCommandError, Exception) as error:
+            raise StepRunnerException(
+                f"Error creating git tag ({git_tag_value}): {error}"
+            ) from error

--- a/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
+++ b/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
@@ -10,9 +10,9 @@ Could come from:
 
 Configuration Key    | Required? | Default              | Description
 ---------------------|-----------|----------------------|-----------
-`git-repo-root`      | Yes       | `.`                  | Directory path to the Git repository to perform git operations on.
+`git-repo-root`      | Yes       | `./`                 | Directory path to the Git repository to perform git operations on.
 `repo-root`          | No        |                      | Alias for `git-repo-root`.
-`git-url`            | No        | Git repo root configured origion url \
+`git-url`            | No        | Git repo root configured origin url \
                                                         | URL to Git repository to perform Git operations on. \
                                                           If not given will use Git remote url set in given Git repository root.
 `url`                | No        |                      | Alias for `git-url`.
@@ -37,15 +37,14 @@ from git.exc import GitCommandError
 from ploigos_step_runner import StepRunnerException
 
 DEFAULT_CONFIG = {
-    'repo-root': './',
+    'git-repo-root': './',
     'git-commit-message': 'Automated commit of changes during release engineering' \
         ' generate-metadata step',
     'git-user-name': 'Ploigos Robot',
     'git-user-email': 'ploigos-robot'
 }
-
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
-    'repo-root'
+    ['git-repo-root', 'repo-root']
 ]
 
 class GitMixin:
@@ -108,7 +107,7 @@ class GitMixin:
                 self.__git_repo = Repo(repo_root)
             except InvalidGitRepositoryError as error:
                 raise StepRunnerException(
-                    f'Given repo-root ({repo_root}) is not a Git repository'
+                    f'Given git-repo-root ({repo_root}) is not a Git repository'
                 ) from error
 
         return self.__git_repo
@@ -129,8 +128,9 @@ class GitMixin:
         if not self.__git_url:
             # get git url from config or current repo remote
             git_url = self.get_value(['git-url', 'url'])
+
             if not git_url:
-                git_url = self.git_repo.remote().url
+                git_url = self.git_repo.remote.url
 
             # get given git username and pass
             git_username = self.get_value('git-username')
@@ -140,15 +140,6 @@ class GitMixin:
             # if git url is http|https combine git username and password with git url
             split_git_url = urlsplit(git_url)
             if split_git_url.scheme in ['ssh']:
-                if git_username:
-                    raise StepRunnerException(
-                        f"Git username ({git_username}) given but git URL ({git_url}) uses SSH."
-                    )
-                if git_password:
-                    raise StepRunnerException(
-                        f"Git password ({git_password}) given but git URL ({git_url}) uses SSH."
-                    )
-
                 self.__git_url = git_url
             elif split_git_url.scheme in ['http', 'https']:
                 # determine git username
@@ -241,14 +232,16 @@ class GitMixin:
             If error pushing changes to remote.
         """
         repo = self.git_repo
+        url = self.git_url
+
         try:
             # NOTE:
             #   using repo.git.push rather then repo.remote().push() because need to be
             #   able to override the git url for the push
-            repo.git.push(self.git_url)
+            repo.git.push(url)
         except (GitCommandError, Exception) as error:
             raise StepRunnerException(
-                f"Error pushing changes to remote ({self.git_url})"
+                f"Error pushing changes to remote ({url})"
                 f" on current branch ({repo.active_branch.name}): {error}"
             ) from error
 
@@ -262,14 +255,16 @@ class GitMixin:
             If error pushing tags to remote.
         """
         repo = self.git_repo
+        url = self.git_url
+
         try:
             # NOTE:
             #   using repo.git.push rather then repo.remote().push() because need to be
             #   able to override the git url for the push
-            repo.git.push(self.git_url, '--tag')
+            repo.git.push(url, '--tag')
         except (GitCommandError, Exception) as error:
             raise StepRunnerException(
-                f"Error pushing tags to remote ({self.git_url})"
+                f"Error pushing tags to remote ({url})"
                 f" on current branch ({repo.active_branch.name}): {error}"
             ) from error
 

--- a/src/ploigos_step_runner/step_implementers/tag_source/git.py
+++ b/src/ploigos_step_runner/step_implementers/tag_source/git.py
@@ -8,27 +8,23 @@ Could come from:
 * runtime configuration
 * previous step results
 
-Configuration Key | Required?          | Default              | Description
-------------------|--------------------|----------------------|-----------
-`url`             | Yes                | git url returned by \
-                                         `git config --get \
-                                         remote.origin.url` \
-                                         in container         | This is the url for the \
-                                                                git server.
-`git-username`    | Yes (if url \
-                    is http or https)  |                      | This is the username to use. \
-                                                                Due to security concerns this \
-                                                                should only be only provided by \
-                                                                the runtime configuration
-`git-password`    | Yes (if url \
-                    is http or https)  |                      | This is the password to use. \
-                                                                Due to security concerns this \
-                                                                should only be only provided by \
-                                                                the runtime configuration
-`version`         | No                 | `latest`             | Semantic version, \
-                                                                if not found this step \
-                                                                will use `latest` as the version \
-                                                                to perform the git tag with
+Configuration Key | Required? | Default  | Description
+------------------|-----------|----------|-----------
+`version`         | No        | `latest` | Semantic version to use as Git tag.
+`git-repo-root`   | Yes       | `.`      | Directory path to the Git repository to perform git operations on.
+`repo-root`       | No        |          | Alias for `git-repo-root`.
+`git-url`         | No        | Git repo root configured origion url \
+                                         | URL to Git repository to perform Git operations on. \
+                                           If not given will use Git remote url set in given Git repository root.
+`url`             | No        |          | Alias for `git-url`.
+`git-username`    | No        |          | Git username to use when connecting with Git remote. \
+                                           Will override username in given git url. \
+                                           Will override username in Git url in Git repository root remote url. \
+                                           Will be ignored if Git repository url is using SSH.
+`git-password`    | No        |          | Git password to use when connecting with Git remote. \
+                                           Will override password in given git url. \
+                                           Will override password in Git url in Git repository root remote url. \
+                                           Will be ignored if Git repository url is using SSH.
 
 Result Artifacts
 ----------------
@@ -37,25 +33,16 @@ Results artifacts output by this step.
 Result Artifact Key | Description
 --------------------|------------
 `tag`               | This is the value that was used to tag the source.
-"""
-import re
-import sys
-from io import StringIO
+"""# pylint: disable=line-too-long
 
-import sh
-from ploigos_step_runner import StepImplementer
+from ploigos_step_runner import StepImplementer, StepResult
 from ploigos_step_runner.exceptions import StepRunnerException
-from ploigos_step_runner import StepResult
+from ploigos_step_runner.step_implementers.shared import GitMixin
 
 DEFAULT_CONFIG = {}
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = []
 
-AUTHENTICATION_CONFIG = {
-    'git-username': None,
-    'git-password': None
-}
-
-
-class Git(StepImplementer):
+class Git(StepImplementer, GitMixin):
     """StepImplementer for the tag-source step for Git.
 
     Note
@@ -79,7 +66,7 @@ class Git(StepImplementer):
         dict
             Default values to use for step configuration values.
         """
-        return DEFAULT_CONFIG
+        return {**GitMixin.step_implementer_config_defaults(), **DEFAULT_CONFIG}
 
     @staticmethod
     def _required_config_or_result_keys():
@@ -96,36 +83,8 @@ class Git(StepImplementer):
             Array of configuration keys or previous step result artifacts
             that are required before running the step.
         """
-        return []
-
-    def _validate_required_config_or_previous_step_result_artifact_keys(self):
-        """Validates that the required configuration keys or previous step result artifacts
-        are set and have valid values.
-
-        Validates that:
-        * required configuration is given
-        * either both git-username and git-password are set or neither.
-
-        Raises
-        ------
-        StepRunnerException
-            If step configuration or previous step result artifacts have invalid required values
-        """
-        super()._validate_required_config_or_previous_step_result_artifact_keys()
-
-        # ensure either both git-username and git-password are set or neither
-        runtime_auth_config = {}
-        for auth_config_key in AUTHENTICATION_CONFIG:
-            runtime_auth_config_value = self.get_value(auth_config_key)
-
-            if runtime_auth_config_value is not None:
-                runtime_auth_config[auth_config_key] = runtime_auth_config_value
-
-        if (any(element in runtime_auth_config for element in AUTHENTICATION_CONFIG)) and \
-                (not all(element in runtime_auth_config for element in AUTHENTICATION_CONFIG)):
-            raise StepRunnerException(
-                "Either 'git-username' or 'git-password 'is not set. Neither or both must be set."
-            )
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS + \
+            GitMixin._required_config_or_result_keys()
 
     def _run_step(self):
         """Runs the step implemented by this StepImplementer.
@@ -137,129 +96,33 @@ class Git(StepImplementer):
         """
         step_result = StepResult.from_step_implementer(self)
 
-        username = None
-        password = None
-
-        if self.has_config_value(AUTHENTICATION_CONFIG):
-            username = self.get_value('git-username')
-            password = self.get_value('git-password')
-        else:
-            print('No username/password found, assuming ssh')
-
-        tag = self.__get_tag()
-
-        try:
-            self.__git_tag(tag)
-            git_url = self.__git_url()
-            if git_url.startswith('http://'):
-                if username and password:
-                    self.__git_push('http://' + username + ':' + password + '@' + git_url[7:])
-                else:
-                    step_result.success = False
-                    step_result.message = 'For a http:// git url, you need to also provide ' \
-                                        'username/password pair'
-                    return step_result
-            elif git_url.startswith('https://'):
-                if username and password:
-                    self.__git_push('https://' + username + ':' + password + '@' + git_url[8:])
-                else:
-                    step_result.success = False
-                    step_result.message = 'For a https:// git url, you need to also provide ' \
-                                        'username/password pair'
-                    return step_result
-            else:
-                self.__git_push(None)
-        except StepRunnerException as error:
-            step_result.success = False
-            step_result.message = str(error)
-
+        # get the tag
+        tag = self.__get_tag_value()
         step_result.add_artifact(
             name='tag',
             value=tag
         )
 
+        # tag and push tags
+        try:
+            self.git_tag(tag)
+            self.git_push_tags()
+        except StepRunnerException as error:
+            step_result.success = False
+            step_result.message = f"Error tagging and pushing tags: {error}"
+
         return step_result
 
-    def __get_tag(self):
+    def __get_tag_value(self):
+        """Get the tag value to tag the Git repository with.
+
+        Returns
+        -------
+        str
+            Value to use for the git tag.
+        """
         tag = self.get_value('version')
         if tag is None:
             tag = 'latest'
             print('No version found in metadata. Using latest')
         return tag
-
-    def __git_url(self):
-        git_url = None
-        if self.get_value('url'):
-            git_url = self.get_value('url')
-        else:
-            try:
-                out = StringIO()
-                sh.git.config(
-                    '--get',
-                    'remote.origin.url',
-                    _encoding='UTF-8',
-                    _decode_errors='ignore',
-                    _out=out,
-                    _err=sys.stderr,
-                    _tee='err'
-                )
-                git_url = out.getvalue().rstrip()
-
-                # remove ANYTHING@ from beginning of git_url since step will pass in its own
-                # username and password
-                #
-                # Regex:
-                #   ^[^@]+@ - match from beginning of line any character up until
-                #             an @ and then the @
-                #   (.*) - match any character and capture to capture group 1
-                #   \1 - capture group 1 which is the http or https if there was one
-                #   \2 - capture group 2 which is anything after the first @ if there was one
-                git_url = re.sub(r"^(http://|https://)[^@]+@(.*)", r"\1\2", git_url)
-
-            except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
-                raise StepRunnerException(
-                    f"Error invoking git config --get remote.origin.url: {error}"
-                ) from error
-        return git_url
-
-    @staticmethod
-    def __git_tag(git_tag_value):
-        try:
-            # NOTE:
-            # this force is only needed locally in case of a re-run of the same pipeline
-            # without a fresh check out. You will notice there is no force on the push
-            # making this an acceptable work around to the issue since on the off chance
-            # actually overwriting a tag with a different comment, the push will fail
-            # because the tag will be attached to a different git hash.
-            sh.git.tag(  # pylint: disable=no-member
-                git_tag_value,
-                '-f',
-                _out=sys.stdout,
-                _err=sys.stderr,
-                _tee='err'
-            )
-        except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
-            raise StepRunnerException(
-                f"Error pushing git tag ({git_tag_value}): {error}"
-            ) from error
-
-    @staticmethod
-    def __git_push(url=None):
-        try:
-            if url:
-                sh.git.push(
-                    url,
-                    '--tag',
-                    _out=sys.stdout,
-                    _err=sys.stderr,
-                    _tee='err'
-                )
-            else:
-                sh.git.push(
-                    '--tag',
-                    _out=sys.stdout,
-                    _err=sys.stderr,
-                    _tee='err'
-                )
-        except sh.ErrorReturnCode as error:  # pylint: disable=undefined-variable
-            raise StepRunnerException(f"Error invoking git push: {error}") from error

--- a/src/ploigos_step_runner/step_implementers/tag_source/git.py
+++ b/src/ploigos_step_runner/step_implementers/tag_source/git.py
@@ -11,9 +11,9 @@ Could come from:
 Configuration Key | Required? | Default  | Description
 ------------------|-----------|----------|-----------
 `version`         | No        | `latest` | Semantic version to use as Git tag.
-`git-repo-root`   | Yes       | `.`      | Directory path to the Git repository to perform git operations on.
+`git-repo-root`   | Yes       | `./`     | Directory path to the Git repository to perform git operations on.
 `repo-root`       | No        |          | Alias for `git-repo-root`.
-`git-url`         | No        | Git repo root configured origion url \
+`git-url`         | No        | Git repo root configured origin url \
                                          | URL to Git repository to perform Git operations on. \
                                            If not given will use Git remote url set in given Git repository root.
 `url`             | No        |          | Alias for `git-url`.
@@ -39,7 +39,15 @@ from ploigos_step_runner import StepImplementer, StepResult
 from ploigos_step_runner.exceptions import StepRunnerException
 from ploigos_step_runner.step_implementers.shared import GitMixin
 
-DEFAULT_CONFIG = {}
+DEFAULT_CONFIG = {
+    'version': 'latest',
+    'git-repo-root': './',
+}
+"""
+Note
+---
+Some required fields inherited from GitMixin (see `_required_config_or_result_keys`)
+"""
 REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = []
 
 class Git(StepImplementer, GitMixin):

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -1,8 +1,7 @@
 
 from unittest.mock import PropertyMock, patch
 
-from git import InvalidGitRepositoryError
-from ploigos_step_runner import StepResult
+from ploigos_step_runner import StepResult, StepRunnerException
 from ploigos_step_runner.step_implementers.generate_metadata import Git
 from testfixtures import TempDirectory
 from tests.helpers.base_step_implementer_test_case import \
@@ -533,8 +532,8 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch('git.Repo')
-    def test_fail_not_a_git_repo(self, mock_repo):
+    @patch.object(Git, 'git_repo', new_callable=PropertyMock)
+    def test_fail_getting_git_repo(self, mock_git_repo):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -547,7 +546,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.side_effect = InvalidGitRepositoryError()
+            mock_git_repo.side_effect = StepRunnerException('mock error')
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -559,8 +558,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 sub_step_implementer_name='Git'
             )
             expected_step_result.success = False
-            expected_step_result.message = f'Given git-repo-root ({temp_dir.path})' \
-                ' is not a Git repository'
+            expected_step_result.message = f'mock error'
 
             self.assertEqual(actual_step_result, expected_step_result)
 

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -27,24 +27,43 @@ class TestStepImplementerGitGenerateMetadataBase(BaseStepImplementerTestCase):
             parent_work_dir_path=parent_work_dir_path
         )
 
+
 class TestStepImplementerGitGenerateMetadata_misc(TestStepImplementerGitGenerateMetadataBase):
+    def test__validate_required_config_or_previous_step_result_artifact_keys(self):
+        step_config = {
+        }
+
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='Git'
+        )
+
+        step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
     def test_step_implementer_config_defaults(self):
         defaults = Git.step_implementer_config_defaults()
         expected_defaults = {
-            'repo-root': './',
-            'release-branch-regexes': ['^main$', '^master$']
+            'git-repo-root': './',
+            'release-branch-regexes': ['^main$', '^master$'],
+            'git-commit-and-push-changes': False,
+            'git-commit-message': 'Automated commit of changes during release engineering'
+                                  ' generate-metadata step',
+            'git-user-name': 'Ploigos Robot',
+            'git-user-email': 'ploigos-robot'
         }
         self.assertEqual(defaults, expected_defaults)
 
     def test__required_config_or_result_keys(self):
         required_keys = Git._required_config_or_result_keys()
         expected_required_keys = [
-            'repo-root'
+            ['git-repo-root', 'repo-root']
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
-@patch('ploigos_step_runner.step_implementers.generate_metadata.git.Repo')
+
 class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGenerateMetadataBase):
+    @patch.object(Git, 'git_repo')
     def test_success_release_branch_default_release_branch_regexes(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -58,10 +77,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'main'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'main'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -87,6 +106,167 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_success_release_branch_default_prerelease_branch_regexes_commit_and_push_always(
+            self,
+            mock_repo,
+            git_url_mock
+    ):
+        # Test data setup
+        branch_name = "not-main"
+
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'git-commit-and-push-changes': 'always'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = branch_name
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            git_url_mock.return_value = "value doesn't matter"
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value=branch_name
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_success_release_branch_default_prerelease_branch_regexes_commit_and_push_always_not_dirty(
+            self,
+            mock_repo,
+            git_url_mock
+    ):
+        # Test data setup
+        branch_name = "not-main"
+
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'git-commit-and-push-changes': 'always'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo.bare = False
+            mock_repo.is_dirty.return_value = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = branch_name
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            git_url_mock.return_value = "value doesn't matter"
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value=branch_name
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=True
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_success_release_branch_default_release_branch_regexes_commit_and_push_always(
+            self,
+            mock_repo,
+            git_url_mock
+    ):
+        # Test data setup
+        branch_name = "main"
+
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'git-commit-and-push-changes': 'always'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = branch_name
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            git_url_mock.return_value = "value doesn't matter"
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value=branch_name
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.add_artifact(
+                name='sha',
+                value='a1b2c3d4e5f6g7h8i9'
+            )
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    @patch.object(Git, 'git_repo')
     def test_success_release_branch_custom_release_branch_regexes_list(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -103,10 +283,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'release/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'release/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -132,6 +312,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_success_release_branch_custom_release_branch_regexes_string(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -146,10 +327,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'release/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'release/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -175,6 +356,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_success_pre_release_branch_default_release_branch_regexes(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -188,10 +370,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'feature/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'feature/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -217,6 +399,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_success_pre_release_branch_custom_release_branch_regexes_list(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -233,10 +416,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'feature/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'feature/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -262,12 +445,13 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_success_pre_release_branch_custom_release_branch_regexes_string(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
                 'repo-root': temp_dir.path,
-                'release-branch-regexes': '^release/.*$'
+                'release-branch-regexes': '^release/.*$',
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
@@ -276,10 +460,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'feature/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'feature/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -305,7 +489,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-
+    @patch.object(Git, 'git_repo')
     def test_success_pre_release_branch_custom_release_branch_regexes_empty(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -320,10 +504,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'feature/mock1'
-            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = 'feature/mock1'
+            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -349,6 +533,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch('git.Repo')
     def test_fail_not_a_git_repo(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -374,12 +559,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 sub_step_implementer_name='Git'
             )
             expected_step_result.success = False
-            expected_step_result.message = f'Given repo-root ({temp_dir.path})' \
+            expected_step_result.message = f'Given git-repo-root ({temp_dir.path})' \
                 ' is not a Git repository'
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-
+    @patch.object(Git, 'git_repo')
     def test_fail_git_repo_bare(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
@@ -393,7 +578,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = True
+            mock_repo.bare = True
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -405,16 +590,16 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 sub_step_implementer_name='Git'
             )
             expected_step_result.success = False
-            expected_step_result.message = f'Given repo-root ({temp_dir.path})' \
-                ' is not a Git repository'
+            expected_step_result.message = f'Given git-repo-root is not a Git repository'
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_fail_is_detached(self, mock_repo):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
-                'repo-root': temp_dir.path
+                'git-repo-root': temp_dir.path
             }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
@@ -423,8 +608,8 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = True
+            mock_repo.bare = False
+            mock_repo.head.is_detached = True
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -436,12 +621,16 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 sub_step_implementer_name='Git'
             )
             expected_step_result.success = False
-            expected_step_result.message = f'Expected a Git branch in given repo_root' \
-                f' ({temp_dir.path}) but has a detached head'
+            expected_step_result.message = f'Expected a Git branch in given git repo root' \
+                f' but has a detached head'
 
             self.assertEqual(actual_step_result, expected_step_result)
 
+    @patch.object(Git, 'git_repo')
     def test_fail_no_commit_history(self, mock_repo):
+        # Data setup
+        git_branch = 'main'
+
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -454,10 +643,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo().bare = False
-            mock_repo().head.is_detached = False
-            mock_repo().head.reference.name = 'main'
-            type(mock_repo().head.reference).commit = PropertyMock(side_effect=ValueError)
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = git_branch
+            type(mock_repo.head.reference).commit = PropertyMock(side_effect=ValueError)
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -470,14 +659,61 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
             expected_step_result.add_artifact(
                 name='branch',
-                value='main'
+                value=git_branch
             )
             expected_step_result.add_artifact(
                 name='is-pre-release',
                 value=False
             )
             expected_step_result.success = False
-            expected_step_result.message =  f'Given repo-root ({temp_dir.path}) is a' \
-                f' git branch (main) with no commit history'
+            expected_step_result.message = f'Given Git repository root is a' \
+                f' git branch ({git_branch}) with no commit history.'
+
+            self.assertEqual(actual_step_result, expected_step_result)
+
+    @patch.object(Git, 'git_repo')
+    def test_run_step_fail_commit_changes_and_push(self, mock_repo):
+        # Data setup
+        git_branch = 'main'
+        error = 'Holy guacamole..!'
+
+        with TempDirectory() as temp_dir:
+            # setup
+            step_config = {
+                'repo-root': temp_dir.path,
+                'git-commit-and-push-changes': True
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                step_name='generate-metadata',
+                implementer='Git'
+            )
+
+            # setup mocks
+            mock_repo.bare = False
+            mock_repo.head.is_detached = False
+            mock_repo.active_branch.name = git_branch
+            mock_repo.git.commit.side_effect = Exception(error)
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='generate-metadata',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(
+                name='branch',
+                value=git_branch
+            )
+            expected_step_result.add_artifact(
+                name='is-pre-release',
+                value=False
+            )
+            expected_step_result.success = False
+            expected_step_result.message = f'Error committing and pushing changes: Error committing changes ' \
+                                           f'to current branch ({git_branch}): {error}'
 
             self.assertEqual(actual_step_result, expected_step_result)

--- a/tests/step_implementers/shared/test_git_mixin.py
+++ b/tests/step_implementers/shared/test_git_mixin.py
@@ -1,0 +1,635 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock, call
+
+from git import InvalidGitRepositoryError, GitCommandError
+from ploigos_step_runner import StepImplementer, StepRunnerException
+from ploigos_step_runner.step_implementers.shared import GitMixin
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+
+
+class GitMixinStepImplementerMock(StepImplementer, GitMixin):
+    def __init__(
+        self,
+        workflow_result,
+        parent_work_dir_path,
+        config,
+        environment=None
+    ):
+        super().__init__(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=environment
+        )
+
+    def _run_step(self):
+        pass
+
+class TestGitMixinBase(BaseStepImplementerTestCase):
+    def create_step_implementer(
+            self,
+            step_config={},
+            parent_work_dir_path='',
+            environment=None
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=GitMixinStepImplementerMock,
+            step_config=step_config,
+            step_name='mock',
+            implementer='GitMixinStepImplementerMock',
+            parent_work_dir_path=parent_work_dir_path,
+            environment=environment
+        )
+
+class TestGitMixin_step_implementer_config_defaults(unittest.TestCase):
+    def test_results(self):
+        defaults = GitMixin.step_implementer_config_defaults()
+        expected_defaults = {
+            'git-repo-root': './',
+            'git-commit-message': 'Automated commit of changes during release engineering' \
+                ' generate-metadata step',
+            'git-user-name': 'Ploigos Robot',
+            'git-user-email': 'ploigos-robot'
+        }
+        self.assertEqual(defaults, expected_defaults)
+
+class TestGitMixin__required_config_or_result_keys(unittest.TestCase):
+    def test_results(self):
+        required_keys = GitMixin._required_config_or_result_keys()
+        expected_required_keys = [
+            ['git-repo-root', 'repo-root']
+        ]
+        self.assertEqual(required_keys, expected_required_keys)
+
+@patch('ploigos_step_runner.step_implementers.shared.git_mixin.Repo')
+class TestGitMixin_git_repo(unittest.TestCase):
+    def test_given_git_repo_root(self, mock_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-repo-root' in key:
+                return 'mock/repo/path'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_repo = step_implementer.git_repo
+
+        # validate
+        self.assertIsNotNone(actual_git_repo)
+        mock_repo.assert_called_once_with('mock/repo/path')
+
+    def test_given_repo_root(self, mock_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'repo-root' in key:
+                return 'mock/repo/path'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_repo = step_implementer.git_repo
+
+        # validate
+        self.assertIsNotNone(actual_git_repo)
+        mock_repo.assert_called_once_with('mock/repo/path')
+
+    def test_multiple_calls(self, mock_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-repo-root' in key:
+                return 'mock/repo/path'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_repo1 = step_implementer.git_repo
+        actual_git_repo2 = step_implementer.git_repo
+
+        # validate
+        self.assertEqual(actual_git_repo1, actual_git_repo2)
+        mock_repo.assert_called_once_with('mock/repo/path')
+
+    def test_repo_error(self, mock_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-repo-root' in key:
+                return 'mock/bad/repo/path'
+        mock_get_value.side_effect = mock_get_value_side_effect
+        mock_repo.side_effect = InvalidGitRepositoryError('mock error')
+
+        # run test
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            "Given git-repo-root \(mock/bad/repo/path\) is not a Git repository: mock error"
+        ):
+            step_implementer.git_repo
+
+        # validate
+        mock_repo.assert_called_once_with('mock/bad/repo/path')
+
+@patch.object(GitMixin, 'git_repo')
+class TestGitMixin_git_url(unittest.TestCase):
+    def test_given_git_url_ssh(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-url' in key:
+                return 'ssh://git@mock.xyz/mock.git'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'ssh://git@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_url_ssh(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'ssh://git@mock.xyz/mock.git'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'ssh://git@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_no_username_no_password(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock.xyz/mock.git'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_http_no_username_no_password(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'http://mock.xyz/mock.git'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'http://mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_username(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock.xyz/mock.git'
+            if 'username' in key:
+                return 'mock-user'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-user@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_username_and_given_config_password(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock.xyz/mock.git'
+            if 'username' in key:
+                return 'mock-user'
+            if 'password' in key:
+                return 'mock-pass'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-user:mock-pass@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_with_port_given_config_username_and_given_config_password(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock.xyz:42/mock.git'
+            if 'username' in key:
+                return 'mock-user'
+            if 'password' in key:
+                return 'mock-pass'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-user:mock-pass@mock.xyz:42/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_username_and_given_config_password_and_given_username_in_url(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock-url-user@mock.xyz/mock.git'
+            if 'username' in key:
+                return 'mock-config-user'
+            if 'password' in key:
+                return 'mock-pass'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-config-user:mock-pass@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_password_and_givin_username_in_url(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock-url-user@mock.xyz/mock.git'
+            if 'password' in key:
+                return 'mock-pass'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-url-user:mock-pass@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_username_and_given_config_password_and_given_password_in_url(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock-url-user:mock-url-pass@mock.xyz/mock.git'
+            if 'username' in key:
+                return 'mock-config-user'
+            if 'password' in key:
+                return 'mock-config-pass'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-config-user:mock-config-pass@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_given_git_url_https_given_config_username_and_given_password_in_url(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'url' in key:
+                return 'https://mock-url-user:mock-url-pass@mock.xyz/mock.git'
+            if 'username' in key:
+                return 'mock-config-user'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'https://mock-config-user:mock-url-pass@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+    def test_url_from_git_repo_ssh(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            return None
+        mock_get_value.side_effect = mock_get_value_side_effect
+        type(mock_git_repo.remote()).url = PropertyMock(return_value='ssh://git@mock.xyz/mock.git')
+
+        # run test
+        actual_git_url1 = step_implementer.git_url
+        actual_git_url2 = step_implementer.git_url
+
+        # validate
+        self.assertEqual(actual_git_url1, 'ssh://git@mock.xyz/mock.git')
+        self.assertEqual(actual_git_url1, actual_git_url2)
+        mock_git_repo.assert_not_called()
+
+@patch.object(GitMixin, 'git_repo')
+class TestGitMixin_configure_git_user(unittest.TestCase):
+    def test_given_git_user_name_and_given_git_user_email(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-user-name' in key:
+                return 'mock-git-user'
+            if 'git-user-email' in key:
+                return 'mock-git-email@mock.xyz'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        step_implementer.configure_git_user()
+
+        # validate
+        mock_git_repo.config_writer().set_value.assert_has_calls([
+            call('user', 'name', 'mock-git-user'),
+            call().release(),
+            call('user', 'email', 'mock-git-email@mock.xyz'),
+            call().release()
+        ])
+
+@patch.object(GitMixin, 'git_repo')
+class TestGitMixin_git_commit_changes(unittest.TestCase):
+    def test_success(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-commit-message' in key:
+                return 'mock commit message'
+        mock_get_value.side_effect = mock_get_value_side_effect
+
+        # run test
+        step_implementer.git_commit_changes()
+
+        # validate
+        mock_git_repo.git.commit.assert_called_with('-am', 'mock commit message')
+
+    def test_fail(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_get_value = MagicMock()
+        step_implementer.get_value = mock_get_value
+        def mock_get_value_side_effect(key):
+            if 'git-commit-message' in key:
+                return 'mock commit message'
+        mock_get_value.side_effect = mock_get_value_side_effect
+        mock_git_repo.git.commit.side_effect = GitCommandError('mock error')
+        type(mock_git_repo.active_branch).name = PropertyMock(return_value='mock-branch')
+
+        # run test
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            r"Error committing changes to current branch \(mock-branch\): Cmd\('mock'\)"
+            r" failed!\s*cmdline: mock error"
+        ):
+            step_implementer.git_commit_changes()
+
+        # validate
+        mock_git_repo.git.commit.assert_called_with('-am', 'mock commit message')
+
+@patch.object(GitMixin, 'git_repo')
+@patch.object(GitMixin, 'git_url', new_callable=PropertyMock)
+class TestGitMixin_git_push(unittest.TestCase):
+    def test_success(self, mock_git_url, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_url.return_value = 'mock-url'
+
+        # run test
+        step_implementer.git_push()
+
+        # validate
+        mock_git_repo.git.push.assert_called_with('mock-url')
+
+    def test_fail(self, mock_git_url, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_url.return_value = 'mock-url'
+        type(mock_git_repo.active_branch).name = PropertyMock(return_value='mock-branch')
+        mock_git_repo.git.push.side_effect = GitCommandError('mock error')
+
+        # run test
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            r"Error pushing changes to remote \(mock-url\) on current branch \(mock-branch\):"
+            r" Cmd\('mock'\) failed!\s*cmdline: mock error"
+        ):
+            step_implementer.git_push()
+
+        # validate
+        mock_git_repo.git.push.assert_called_with('mock-url')
+
+@patch.object(GitMixin, 'git_repo')
+@patch.object(GitMixin, 'git_url', new_callable=PropertyMock)
+class TestGitMixin_git_push_tags(unittest.TestCase):
+    def test_success(self, mock_git_url, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_url.return_value = 'mock-url'
+
+        # run test
+        step_implementer.git_push_tags()
+
+        # validate
+        mock_git_repo.git.push.assert_called_with('mock-url', '--tag')
+
+    def test_fail(self, mock_git_url, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_url.return_value = 'mock-url'
+        type(mock_git_repo.active_branch).name = PropertyMock(return_value='mock-branch')
+        mock_git_repo.git.push.side_effect = GitCommandError('mock error')
+
+        # run test
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            r"Error pushing tags to remote \(mock-url\) on current branch \(mock-branch\):"
+            r" Cmd\('mock'\) failed!\s*cmdline: mock error"
+        ):
+            step_implementer.git_push_tags()
+
+        # validate
+        mock_git_repo.git.push.assert_called_with('mock-url', '--tag')
+
+@patch.object(GitMixin, 'git_repo')
+@patch.object(GitMixin, 'configure_git_user')
+@patch.object(GitMixin, 'git_commit_changes')
+@patch.object(GitMixin, 'git_push')
+class TestGitMixin_commit_changes_and_push(unittest.TestCase):
+    def test_is_dirty(self, mock_git_push, mock_git_commit_changes, mock_configure_git_user, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_repo.is_dirty.return_value = True
+
+        # run test
+        step_implementer.commit_changes_and_push()
+
+        # validate
+        mock_configure_git_user.assert_called_once_with()
+        mock_git_commit_changes.assert_called_once_with()
+        mock_git_push.assert_called_once_with()
+
+    def test_not_dirty(self, mock_git_push, mock_git_commit_changes, mock_configure_git_user, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # set up mocks
+        mock_git_repo.is_dirty.return_value = False
+
+        # run test
+        step_implementer.commit_changes_and_push()
+
+        # validate
+        mock_configure_git_user.assert_not_called()
+        mock_git_commit_changes.assert_not_called()
+        mock_git_push.assert_not_called()
+
+@patch.object(GitMixin, 'git_repo')
+class TestGitMixin_git_tag(unittest.TestCase):
+    def test_success(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # run test
+        step_implementer.git_tag(
+            git_tag_value='v0.42.0-mock'
+        )
+
+        # validate
+        mock_git_repo.create_tag.assert_called_once_with('v0.42.0-mock', force=True)
+
+    def test_fail(self, mock_git_repo):
+        # setup
+        step_implementer = GitMixin()
+
+        # setup mock
+        mock_git_repo.create_tag.side_effect = GitCommandError('mock error')
+
+        # run test
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            r"Error creating git tag \(v0.42.0-mock\): Cmd\('mock'\) failed!\s*cmdline: mock error"
+        ):
+            step_implementer.git_tag(
+                git_tag_value='v0.42.0-mock'
+            )
+
+        # validate
+        mock_git_repo.create_tag.assert_called_once_with('v0.42.0-mock', force=True)

--- a/tests/step_implementers/tag_source/test_git_tag_source.py
+++ b/tests/step_implementers/tag_source/test_git_tag_source.py
@@ -2,15 +2,11 @@
 # pylint: disable=missing-class-docstring
 # pylint: disable=missing-function-docstring
 import os
-import re
-from io import IOBase
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
-import sh
 from testfixtures import TempDirectory
 from tests.helpers.base_step_implementer_test_case import \
     BaseStepImplementerTestCase
-from tests.helpers.test_utils import Any
 from ploigos_step_runner.exceptions import StepRunnerException
 from ploigos_step_runner.step_implementers.tag_source import Git
 from ploigos_step_runner import StepResult
@@ -35,12 +31,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 # TESTS FOR configuration checks
     def test_step_implementer_config_defaults(self):
         defaults = Git.step_implementer_config_defaults()
-        expected_defaults = {}
+        expected_defaults = {
+            'version': 'latest',
+            'git-repo-root': './',
+            'git-commit-message': 'Automated commit of changes during release engineering' \
+                                  ' generate-metadata step',
+            'git-user-name': 'Ploigos Robot',
+            'git-user-email': 'ploigos-robot'
+        }
         self.assertEqual(defaults, expected_defaults)
 
     def test__required_config_or_result_keys(self):
         required_keys = Git._required_config_or_result_keys()
-        expected_required_keys = []
+        expected_required_keys = [
+            ['git-repo-root', 'repo-root'],
+        ]
         self.assertEqual(required_keys, expected_required_keys)
 
     def test__validate_required_config_or_previous_step_result_artifact_keys_valid(self):
@@ -58,50 +63,11 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
 
             step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
 
-    def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_username(self):
-         with TempDirectory() as test_dir:
-            parent_work_dir_path = os.path.join(test_dir.path, 'working')
-
-            step_config = {
-                'git-password': 'git-password'
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            with self.assertRaisesRegex(
-                StepRunnerException,
-                r"Either 'git-username' or 'git-password 'is not set. Neither or both must be set."
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
-
-    def test__validate_required_config_or_previous_step_result_artifact_keys_invalid_missing_git_password(self):
-         with TempDirectory() as test_dir:
-            parent_work_dir_path = os.path.join(test_dir.path, 'working')
-
-            step_config = {
-                'git-username': 'git-username'
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                parent_work_dir_path=parent_work_dir_path,
-            )
-
-            with self.assertRaisesRegex(
-                StepRunnerException,
-                r"Either 'git-username' or 'git-password 'is not set. Neither or both must be set."
-            ):
-                step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
-
-
 # TESTS FOR _run_step
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_pass(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass(self, git_repo_mock, git_url_mock):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
@@ -110,7 +76,8 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             step_config = {
                 'url': url,
                 'git-username': 'git-username',
-                'git-password': 'git-password'
+                'git-password': 'git-password',
+                'version': tag
             }
 
             artifact_config = {
@@ -126,14 +93,7 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path,
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
+            git_url_mock.return_value = url
 
             result = step_implementer._run_step()
 
@@ -141,18 +101,62 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(name='tag', value=tag)
 
             # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
             git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with(None)
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
 
             self.assertEqual(result, expected_step_result)
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_pass_http(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
+    '''
+    TODO: Is this test case possible with the new logic? (i.e., can 'version' / 'tag' ever be empty?)
+    '''
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_no_tag(self, git_repo_mock, git_url_mock):
+        with TempDirectory() as temp_dir:
+            url = 'git@github.com:ploigos/ploigos-step-runner.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            step_config = {
+                'url': url,
+                'git-username': 'git-username',
+                'git-password': 'git-password',
+                'version': None
+            }
+
+            #artifact_config = {
+            #    'version': {'description': '', 'value': tag},
+            #    'container-image-version': {'description': '', 'value': tag}
+            #}
+
+            artifact_config = {}
+
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            git_url_mock.return_value = url
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
+            expected_step_result.add_artifact(name='tag', value='latest')
+
+            # verifying all mocks were called
+            git_url_mock.assert_called_once_with()
+            git_repo_mock.create_tag.assert_called_once_with('latest', force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_http(self, git_repo_mock, git_url_mock, get_tag_value_mock):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
@@ -174,14 +178,8 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
+            get_tag_value_mock.return_value = tag
+            git_url_mock.return_value = url
 
             result = step_implementer._run_step()
 
@@ -189,18 +187,206 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(name='tag', value=tag)
 
             # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
             git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with('http://git-username:git-password@' + url[7:])
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
 
             self.assertEqual(result, expected_step_result)
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_pass_https(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
+    '''
+    TODO: URL splitting should be pulled into a utility class and tested separately
+    '''
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_http_nonstandard_port(self, git_repo_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            git_username = 'git-username'
+            git_password = 'git-password'
+            url = 'http://git.ploigos.xyz:8080/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
+            target_url = f'http://{git_username}:{git_password}@git.ploigos.xyz:8080/ploigos-references/' \
+                         f'ploigos-reference-app-quarkus-rest-json.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url,
+                'git-username': 'git-username',
+                'git-password': 'git-password'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(
+                step_name='tag-source',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(target_url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    '''
+    TODO: URL splitting should be pulled into a utility class and tested separately
+    '''
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_http_username_provided_twice(self, git_repo_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            git_username = 'git-username'
+            git_password = 'git-password'
+            url = 'http://fake-user:fake-password@git.ploigos.xyz/ploigos-references/' \
+                  'ploigos-reference-app-quarkus-rest-json.git'
+            target_url = f'http://{git_username}:{git_password}@git.ploigos.xyz/ploigos-references/' \
+                         f'ploigos-reference-app-quarkus-rest-json.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url,
+                'git-username': 'git-username',
+                'git-password': 'git-password'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(
+                step_name='tag-source',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(target_url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    '''
+    TODO: URL splitting should be pulled into a utility class and tested separately
+    '''
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_http_username_and_password_from_url(self, git_repo_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            git_username = 'git-username'
+            git_password = 'git-password'
+            url = f'http://{git_username}:{git_password}@git.ploigos.xyz/ploigos-references/' \
+                  'ploigos-reference-app-quarkus-rest-json.git'
+            target_url = f'http://{git_username}:{git_password}@git.ploigos.xyz/ploigos-references/' \
+                         f'ploigos-reference-app-quarkus-rest-json.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(
+                step_name='tag-source',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(target_url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    '''
+    TODO: URL splitting should be pulled into a utility class and tested separately
+    '''
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_http_username_from_url_no_password(self, git_repo_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            git_username = 'git-username'
+            url = f'http://{git_username}@git.ploigos.xyz/ploigos-references/' \
+                  'ploigos-reference-app-quarkus-rest-json.git'
+            target_url = f'http://{git_username}@git.ploigos.xyz/ploigos-references/' \
+                         f'ploigos-reference-app-quarkus-rest-json.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(
+                step_name='tag-source',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git'
+            )
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(target_url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_https(self, git_repo_mock, git_url_mock, get_tag_value_mock):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
@@ -223,14 +409,8 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
+            get_tag_value_mock.return_value = tag
+            git_url_mock.return_value = url
 
             result = step_implementer._run_step()
 
@@ -238,161 +418,21 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             expected_step_result.add_artifact(name='tag', value=tag)
 
             # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
             git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with('https://git-username:git-password@' + url[8:])
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
+
+            get_tag_value_mock.assert_called_once_with()
 
             self.assertEqual(result, expected_step_result)
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_pass_no_username_password(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_ssh(self, git_repo_mock, git_url_mock, get_tag_value_mock):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
-            url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'url': url
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
-            expected_step_result.add_artifact(name='tag', value=tag)
-
-            # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
-            git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with(None)
-
-            self.assertEqual(result, expected_step_result)
-
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_fail_http_no_username_password(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
-        with TempDirectory() as temp_dir:
-            tag = '1.0+69442c8'
-            url = 'http://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'url': url
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
-            expected_step_result.success = False
-            expected_step_result.message = 'For a http:// git url, you need to also provide username/password pair'
-
-            # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
-            git_url_mock.assert_called_once_with()
-
-            self.assertEqual(result, expected_step_result)
-
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_fail_https_no_username_password(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
-        with TempDirectory() as temp_dir:
-            tag = '1.0+69442c8'
-            url = 'https://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'version': {'description': '', 'value': tag},
-                'container-image-version': {'description': '', 'value': tag}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {
-                'url': url
-            }
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
-            result = step_implementer._run_step()
-
-            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
-            expected_step_result.success = False
-            expected_step_result.message = 'For a https:// git url, you need to also provide username/password pair'
-
-            # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
-            git_url_mock.assert_called_once_with()
-
-            self.assertEqual(result, expected_step_result)
-
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_error_git_tag(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
-        with TempDirectory() as temp_dir:
-            tag = '1.0+69442c8'
-            url = 'git@github.com:ploigos/ploigos-step-runner.git'
+            url = 'ssh://git.ploigos.xyz/ploigos-references/ploigos-reference-app-quarkus-rest-json.git'
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
             artifact_config = {
@@ -412,16 +452,94 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
+            get_tag_value_mock.return_value = tag
+            git_url_mock.return_value = url
 
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_url_mock.assert_called_once_with()
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
+
+            get_tag_value_mock.assert_called_once_with()
+
+            self.assertEqual(result, expected_step_result)
+
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_pass_no_username_password(self, git_repo_mock, git_url_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            url = 'git@github.com:ploigos/ploigos-step-runner.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+            git_url_mock.return_value = url
+
+            result = step_implementer._run_step()
+
+            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
+            expected_step_result.add_artifact(name='tag', value=tag)
+
+            # verifying all mocks were called
+            git_url_mock.assert_called_once_with()
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
+
+            self.assertEqual(result, expected_step_result)
+
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_error_git_tag(self, git_repo_mock, git_url_mock, get_tag_value_mock):
+        with TempDirectory() as temp_dir:
+            tag = '1.0+69442c8'
+            url = 'git@github.com:ploigos/ploigos-step-runner.git'
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+            error = 'I AM ERROR'
+
+            artifact_config = {
+                'version': {'description': '', 'value': tag},
+                'container-image-version': {'description': '', 'value': tag}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {
+                'url': url,
+                'git-username': 'git-username',
+                'git-password': 'git-password'
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
+            )
+
+            get_tag_value_mock.return_value = tag
+            git_url_mock.return_value = url
 
             # this is the test
-            git_tag_mock.side_effect = StepRunnerException('mock error')
+            git_repo_mock.create_tag.side_effect = Exception(error)
             result = step_implementer._run_step()
 
             # verify results
@@ -432,22 +550,22 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='tag', value=tag)
             expected_step_result.success = False
-            expected_step_result.message = "mock error"
+            expected_step_result.message = f"Error tagging and pushing tags: Error creating git tag ({tag}): {error}"
 
             # verifying correct mocks were called
-            git_tag_mock.assert_called_once_with(tag)
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
 
             self.assertEqual(result, expected_step_result)
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_error_git_url(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_error_git_url(self, git_repo_mock, git_url_mock, get_tag_value_mock):
         with TempDirectory() as temp_dir:
             tag = '1.0+69442c8'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+            error = 'uh oh spaghetti-os'
 
             artifact_config = {
                 'version': {'description': '', 'value': tag},
@@ -466,12 +584,10 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
+            get_tag_value_mock.return_value = tag
 
             # this is the test here
-            git_url_mock.side_effect = StepRunnerException('mock error')
+            git_url_mock.side_effect = StepRunnerException(error)
             result = step_implementer._run_step()
 
             # verify test results
@@ -482,24 +598,31 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='tag', value=tag)
             expected_step_result.success = False
-            expected_step_result.message = "mock error"
+            expected_step_result.message = f"Error tagging and pushing tags: {error}"
 
             # verifying correct mocks were called
-            git_tag_mock.assert_called_once_with(tag)
-            git_url_mock.assert_called_once_with()
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
+            git_url_mock.assert_called_once()
 
             self.assertEqual(result, expected_step_result)
 
-    @patch.object(Git, '_Git__get_tag')
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test_run_step_error_git_push(self, git_push_mock, git_tag_mock, git_url_mock, get_tag_mock):
-        with TempDirectory() as temp_dir:
-            tag = '1.0+69442c8'
-            url = 'git@github.com:ploigos/ploigos-step-runner.git'
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+    @patch.object(Git, '_Git__get_tag_value')
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test_run_step_error_git_push(self, git_repo_mock, git_url_mock, get_tag_value_mock):
+        # Test data setup
+        tag = '1.0+69442c8'
+        url = 'git@github.com:ploigos/ploigos-step-runner.git'
+        error = 'oh no. ohhhhh no.'
+        branch_name = 'feature/no-feature'
 
+        # Mock setup
+        get_tag_value_mock.return_value = tag
+        git_url_mock.return_value = url
+        git_repo_mock.active_branch.name = branch_name
+
+        with TempDirectory() as temp_dir:
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
             artifact_config = {
                 'version': {'description': '', 'value': tag},
                 'container-image-version': {'description': '', 'value': tag}
@@ -517,16 +640,8 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def get_tag_side_effect():
-                return tag
-            get_tag_mock.side_effect = get_tag_side_effect
-
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
             # this is the test here
-            git_push_mock.side_effect = StepRunnerException('mock error')
+            git_repo_mock.git.push.side_effect = Exception(error)
             result = step_implementer._run_step()
 
             # verify the test results
@@ -537,22 +652,22 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             )
             expected_step_result.add_artifact(name='tag', value=tag)
             expected_step_result.success = False
-            expected_step_result.message = "mock error"
+            expected_step_result.message = f"Error tagging and pushing tags: Error pushing tags to remote ({url})" \
+                f" on current branch ({branch_name}): {error}"
 
             # verifying all mocks were called
-            get_tag_mock.assert_called_once_with()
-            git_tag_mock.assert_called_once_with(tag)
+            git_repo_mock.create_tag.assert_called_once_with(tag, force=True)
             git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with(None)
+            git_repo_mock.git.push.assert_called_once_with(url, '--tag')
 
             self.assertEqual(result, expected_step_result)
 
 # TEST FOR __get_tag
 
-    @patch.object(Git, '_Git__git_url')
-    @patch.object(Git, '_Git__git_tag')
-    @patch.object(Git, '_Git__git_push')
-    def test__get_tag_no_version(self, git_push_mock, git_tag_mock, git_url_mock):
+    @patch.object(Git, 'git_url')
+    @patch.object(Git, 'git_tag')
+    @patch.object(Git, 'git_repo')
+    def test__get_tag_no_version(self, git_repo_mock, git_tag_mock, git_url_mock):
         with TempDirectory() as temp_dir:
             tag = 'latest'
             url = 'git@github.com:ploigos/ploigos-step-runner.git'
@@ -572,85 +687,22 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            def git_url_side_effect():
-                return url
-            git_url_mock.side_effect = git_url_side_effect
-
-
             result = step_implementer._run_step()
 
-            expected_step_result = StepResult(step_name='tag-source', sub_step_name='Git', sub_step_implementer_name='Git')
+            expected_step_result = StepResult(
+                step_name='tag-source',
+                sub_step_name='Git',
+                sub_step_implementer_name='Git')
             expected_step_result.add_artifact(name='tag', value=tag)
 
             # verifying all mocks were called
             git_tag_mock.assert_called_once_with(tag)
-            git_url_mock.assert_called_once_with()
-            git_push_mock.assert_called_once_with(None)
+            git_repo_mock.git.push.assert_called_once_with(git_url_mock, '--tag')
 
             self.assertEqual(result, expected_step_result)
 
-# TESTS FOR __git_url
-
-    def create_git_config_side_effect(self, mock_remote_origin_url):
-        def git_config_side_effect(*args, **kwargs):
-            if (args[0] == '--get' and args[1] == 'remote.origin.url'):
-                kwargs['_out'].write(mock_remote_origin_url)
-
-        return git_config_side_effect
-
-    @patch('sh.git', create=True)
-    def test__git_url_url_from_git_config(self, git_mock):
-        remote_origin_url = "https://does.not.matter.xyz/foo.git"
-
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-69442c8'}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {}
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            git_mock.config.side_effect = TestStepImplementerTagSourceGit.\
-                create_git_config_side_effect(self, remote_origin_url)
-
-            url = step_implementer._Git__git_url()
-
-            self.assertEqual(url, remote_origin_url)
-
-    @patch('sh.git', create=True)
-    def test__git_url_url_from_git_config_error(self, git_mock):
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-69442c8'}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {}
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            git_mock.config.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
-
-            with self.assertRaisesRegex(
-                StepRunnerException,
-                "Error invoking git config --get remote.origin.url:"
-            ):
-                step_implementer._Git__git_url()
-
-    @patch('sh.git', create=True)
-    def test__git_url_from_step_config(self, git_mock):
+    @patch.object(Git, 'git_repo')
+    def test__git_url_from_step_config(self, git_repo_mock):
         remote_origin_url = "https://does.not.matter.xyz/foo.git"
 
         with TempDirectory() as temp_dir:
@@ -670,16 +722,16 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            git_mock.assert_not_called()
+            git_repo_mock.assert_not_called()
 
-            url = step_implementer._Git__git_url()
+            url = step_implementer.git_url
 
             self.assertEqual(url, remote_origin_url)
 
 # TESTS FOR __git_tag
 
-    @patch('sh.git', create=True)
-    def test__git_tag_success(self, git_mock):
+    @patch.object(Git, 'git_repo')
+    def test__git_tag_success(self, git_repo_mock):
         git_tag_value = "1.0+69442c8"
 
         with TempDirectory() as temp_dir:
@@ -697,19 +749,17 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            step_implementer._Git__git_tag(git_tag_value)
+            step_implementer.git_tag(git_tag_value)
 
-            git_mock.tag.assert_called_once_with(
+            git_repo_mock.create_tag.assert_called_once_with(
                 git_tag_value,
-                '-f',
-                _out=Any(IOBase),
-                _err=Any(IOBase),
-                _tee='err'
+                force=True
             )
 
-    @patch('sh.git', create=True)
-    def test__git_tag_error(self, git_mock):
+    @patch.object(Git, 'git_repo')
+    def test__git_tag_error(self, git_repo_mock):
         git_tag_value = "1.0+69442c8"
+        error = 'Uh oh!'
 
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
@@ -726,47 +776,22 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            git_mock.tag.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
+            git_repo_mock.create_tag.side_effect = Exception(error)
 
-            with self.assertRaisesRegex(
+            with self.assertRaisesMessage(
                 StepRunnerException,
-                "Error pushing git tag"
+                f"Error creating git tag ({git_tag_value}): {error}"
             ):
-                step_implementer._Git__git_tag(git_tag_value)
+                step_implementer.git_tag(git_tag_value)
 
 # TESTS FOR __git_push
 
-    @patch('sh.git', create=True)
-    def test__git_push_with_url_success(self, git_mock):
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test__git_push_with_url_success(self, git_repo_mock, git_url_mock):
         url = 'www.xyz.com'
 
-        with TempDirectory() as temp_dir:
-            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
-
-            artifact_config = {
-                'container-image-version': {'description': '', 'value': '1.0-69442c8'}
-            }
-            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
-
-            step_config = {}
-            step_implementer = self.create_step_implementer(
-                step_config=step_config,
-                workflow_result=workflow_result,
-                parent_work_dir_path=parent_work_dir_path
-            )
-
-            step_implementer._Git__git_push(url)
-
-            git_mock.push.assert_called_once_with(
-                url,
-                '--tag',
-                _out=Any(IOBase),
-                _err=Any(IOBase),
-                _tee='err'
-            )
-
-    @patch('sh.git', create=True)
-    def test__git_push_no_url_success(self, git_mock):
+        git_url_mock.return_value = url
 
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
@@ -783,19 +808,49 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            step_implementer._Git__git_push(None)
+            step_implementer.git_push()
 
-            git_mock.push.assert_called_once_with(
-                '--tag',
-                _out=Any(IOBase),
-                _err=Any(IOBase),
-                _tee='err'
+            git_repo_mock.git.push.assert_called_once_with(url)
+
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test__git_push_no_url_success(self, git_repo_mock, git_url_mock):
+        git_url_mock.return_value = None
+
+        with TempDirectory() as temp_dir:
+            parent_work_dir_path = os.path.join(temp_dir.path, 'working')
+
+            artifact_config = {
+                'container-image-version': {'description': '', 'value': '1.0-69442c8'}
+            }
+            workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
+
+            step_config = {}
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                workflow_result=workflow_result,
+                parent_work_dir_path=parent_work_dir_path
             )
 
-    @patch('sh.git', create=True)
-    def test__git_push_error(self, git_mock):
+            step_implementer.git_push()
+
+            git_repo_mock.git.push.assert_called_once_with(None)
+
+    @patch.object(Git, 'git_url', new_callable=PropertyMock)
+    @patch.object(Git, 'git_repo')
+    def test__git_push_error(self, git_repo_mock, git_url_mock):
+        # Data setup
         url = 'www.xyz.com'
+        branch_name = 'latest'
+        error = 'Whoops!'
 
+        # Mock setup
+        git_url_mock.return_value = url
+
+        git_repo_mock.active_branch.name = branch_name
+        git_repo_mock.git.push.side_effect = Exception(error)
+
+        # Run test
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
 
@@ -804,17 +859,18 @@ class TestStepImplementerTagSourceGit(BaseStepImplementerTestCase):
             }
             workflow_result = self.setup_previous_result(parent_work_dir_path, artifact_config)
 
-            step_config = {}
+            step_config = {
+                'git-url': url
+            }
             step_implementer = self.create_step_implementer(
                 step_config=step_config,
                 workflow_result=workflow_result,
                 parent_work_dir_path=parent_work_dir_path
             )
 
-            git_mock.push.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock error')
-
-            with self.assertRaisesRegex(
+            with self.assertRaisesMessage(
                 StepRunnerException,
-                "Error invoking git push"
+                f"Error pushing changes to remote ({url})"
+                f" on current branch ({branch_name}): {error}"
             ):
-                step_implementer._Git__git_push(url)
+                step_implementer.git_push()


### PR DESCRIPTION
# Purpose

Add the ability to commit git changes during the gen metadata step, if for instance, you were auto incrementing the version during that step and wanted to persist that.

# Breaking?
No

# Integration Testing
tested this with a few internal apps to make sure it is none breaking. as in tested without changing any PSR config. 
also tested enabling the new option to be sure it works as expected.
