### PR TITLE
ArgoCD - make it even smarter so will try again no matter what state it transitions from to Degraded when waiting for Healthy after sync

### DIFF
--- a/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
@@ -29,7 +29,7 @@ class ArgoCDGeneric(StepImplementer):
         re.DOTALL
     )
     ARGOCD_HEALTH_STATE_TRANSITIONED_FROM_HEALTHY_TO_DEGRADED = re.compile(
-        r".*level=fatal.*health\s+state\s+has\s+transitioned\s+from\s+Healthy\s+to\s+Degraded",
+        r".*level=fatal.*health\s+state\s+has\s+transitioned\s+from\s.+\s+to\s+Degraded",
         re.DOTALL
     )
     MAX_ATTEMPT_TO_WAIT_FOR_ARGOCD_OP_RETRIES = 2


### PR DESCRIPTION
# Purpose
Follow on to https://github.com/ploigos/ploigos-step-runner/pull/244 to make ArgoCD code even smarter and deal with any transition to Degraded.

Tl;dr, more permisive regex check.

# Breaking?
No

# Integration Testing
internal envirnoment.
