### PR TITLE
generate-metadata.SemanticVersion - update to include 'build' portion

### DIFF
--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -35,7 +35,8 @@ class TestStepImplementerSemanticVersionGenerateMetadata_misc(
         defaults = SemanticVersion.step_implementer_config_defaults()
         expected_defaults = {
             'is-pre-release': False,
-            'sha-build-identifier-length': 7
+            'sha-build-identifier-length': 7,
+            'container-image-tag-build-deliminator': '_'
         }
         self.assertEqual(defaults, expected_defaults)
 
@@ -43,7 +44,8 @@ class TestStepImplementerSemanticVersionGenerateMetadata_misc(
         required_keys = SemanticVersion._required_config_or_result_keys()
         expected_required_keys = [
             'app-version',
-            'is-pre-release'
+            'is-pre-release',
+            'container-image-tag-build-deliminator'
         ]
         self.assertEqual(required_keys, expected_required_keys)
 
@@ -139,7 +141,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata__run_step(
         )
         expected_step_result.add_artifact(
             name='container-image-tag',
-            value='0.42.1',
+            value='0.42.1_mock1',
             description='Constructed semenatic version without build identifier' \
               ' since not compatible with container image tags'
         )
@@ -160,7 +162,69 @@ class TestStepImplementerSemanticVersionGenerateMetadata__run_step(
         )
         expected_step_result.add_evidence(
             name='container-image-tag',
+            value='0.42.1_mock1',
+            description='semenatic version without build identifier' \
+                ' since not compatible with container image tags'
+        )
+
+        self.assertEqual(actual_result, expected_step_result)
+        mock_pre_release.assert_not_called()
+        mock_build.assert_called_once()
+
+    def test_app_version_and_build_custom_container_image_tag_build_deliminator(self, mock_build, mock_pre_release):
+        # setup
+        step_config = {
+            'app-version': '0.42.1',
+            'container-image-tag-build-deliminator': '_-_'
+        }
+        step_implementer = self.create_step_implementer(
+            step_config=step_config,
+            step_name='generate-metadata',
+            implementer='SemanticVersion'
+        )
+
+        # setup mocks
+        mock_build.return_value = 'mock1'
+        mock_pre_release.return_value = None
+
+        # run test
+        actual_result= step_implementer._run_step()
+
+        # verify results
+        expected_step_result = StepResult(
+            step_name='generate-metadata',
+            sub_step_name='SemanticVersion',
+            sub_step_implementer_name='SemanticVersion'
+        )
+        expected_step_result.add_artifact(
+            name='version',
+            value='0.42.1+mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_artifact(
+            name='container-image-tag',
+            value='0.42.1_-_mock1',
+            description='Constructed semenatic version without build identifier' \
+              ' since not compatible with container image tags'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-core',
             value='0.42.1',
+            description='Semantic version version core portion'
+        )
+        expected_step_result.add_artifact(
+            name='semantic-version-build',
+            value='mock1',
+            description='Semantic version build portion'
+        )
+        expected_step_result.add_evidence(
+            name='version',
+            value='0.42.1+mock1',
+            description='Full constructured semantic version'
+        )
+        expected_step_result.add_evidence(
+            name='container-image-tag',
+            value='0.42.1_-_mock1',
             description='semenatic version without build identifier' \
                 ' since not compatible with container image tags'
         )
@@ -322,7 +386,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata__run_step(
         )
         expected_step_result.add_artifact(
             name='container-image-tag',
-            value='0.42.1-feature-mock1',
+            value='0.42.1-feature-mock1_mock3',
             description='Constructed semenatic version without build identifier' \
               ' since not compatible with container image tags'
         )
@@ -348,7 +412,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata__run_step(
         )
         expected_step_result.add_evidence(
             name='container-image-tag',
-            value='0.42.1-feature-mock1',
+            value='0.42.1-feature-mock1_mock3',
             description='semenatic version without build identifier' \
                 ' since not compatible with container image tags'
         )


### PR DESCRIPTION
# Purpose

generate-metadata.SemanticVersion - update to include 'build' portion of semvar in container image tags using '_' instead of '+' since '+' isn't supported by container image tag syntax but not having the 'build' porition of the version on the tag can cause tags to unexpectedly get overwritten/lost if major.minor.patch isn't updated by application devs

# Breaking?
No

# Integration Testing
TODO
