### PR TITLE
Add support for npm push-artifacts step

### DIFF
--- a/src/ploigos_step_runner/step_implementers/push_artifacts/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/push_artifacts/__init__.py
@@ -3,3 +3,4 @@
 
 from ploigos_step_runner.step_implementers.push_artifacts.maven_deploy import MavenDeploy
 from ploigos_step_runner.step_implementers.push_artifacts.maven import Maven
+from ploigos_step_runner.step_implementers.push_artifacts.npm_push_artifacts import NpmPushArtifacts

--- a/src/ploigos_step_runner/step_implementers/push_artifacts/npm_push_artifacts.py
+++ b/src/ploigos_step_runner/step_implementers/push_artifacts/npm_push_artifacts.py
@@ -1,0 +1,132 @@
+"""`StepImplementer` for the `push-artifacts` step using npm.
+
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+
+  * static configuration
+  * runtime configuration
+  * previous step results
+
+Configuration Key            | Required? | Default | Description
+-----------------------------|-----------|---------|-----------
+`package-file`               | No        | `'package.json'` | package.json file for reference app.
+`npm-envs`                   | No        |                  | Environment vars to pass to NPM.
+`npm-args`                   | Yes       | `None`           | Arguments to pass to the npm command.
+'npm-registry'               | Yes       | `None`           | Push artifacts to this registry.
+'npm-user'                   | Yes       | `None`           | Authenticate to the registry as this
+                                                              user.
+'npm-password'               | Yes       | `None`           | Authenticate to the registry with
+                                                              this password.
+
+Result Artifacts
+----------------
+Results artifacts output by this step.
+
+Result Artifact Key | Description
+--------------------|------------
+"""
+
+from base64 import b64encode
+from ploigos_step_runner import StepResult, StepRunnerException
+from ploigos_step_runner.step_implementers.shared.npm_generic import NpmGeneric
+
+DEFAULT_CONFIG = {}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+    'npm-registry',
+    'npm-user',
+    'npm-password'
+]
+
+class NpmPushArtifacts(NpmGeneric):
+    """`StepImplementer` for the `push-artifacts` step using Maven.
+    """
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        workflow_result,
+        parent_work_dir_path,
+        config,
+        environment=None
+    ):
+        super().__init__(
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path,
+            config=config,
+            environment=environment,
+            npm_args='publish',
+        )
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+        """
+        return {**NpmGeneric.step_implementer_config_defaults(), **DEFAULT_CONFIG}
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    def _run_step(self): # pylint: disable=too-many-locals
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+
+        step_result = StepResult.from_step_implementer(self)
+
+        try:
+            self._execute_npm_publish()
+        except StepRunnerException as error:
+            self._handle_step_runner_exception(step_result, error)
+        finally:
+            pass
+
+        return step_result
+
+    def _execute_npm_publish(self):
+        self._run_npm_step(
+            npm_output_file_path=self.write_working_file('npm_publish_output.txt'),
+            step_implementer_additional_envs=self._generate_npm_env_args()
+        )
+
+    def _generate_npm_env_args(self):
+        auth_string = self.get_value('npm-user') + ':' + self.get_value('npm-password')
+        encoded_auth_string = b64encode(auth_string.encode()).decode()
+        env = {
+            'NPM_CONFIG_REGISTRY': self.get_value('npm-registry'),
+            'NPM_CONFIG__AUTH': encoded_auth_string
+        }
+        return env
+
+    @staticmethod
+    def _handle_step_runner_exception(step_result, error):
+        step_result.message = "NPM publish failure.  See 'npm_publish_output.txt' " \
+                              f"report artifacts for details: {error}"
+        step_result.success = False

--- a/tests/step_implementers/push_artifacts/test_npm_push_artifacts.py
+++ b/tests/step_implementers/push_artifacts/test_npm_push_artifacts.py
@@ -1,0 +1,155 @@
+
+import os
+
+from base64 import b64decode
+from io import StringIO
+from unittest.mock import PropertyMock, patch
+from ploigos_step_runner import WorkflowResult, StepRunnerException
+from ploigos_step_runner.step_implementers.push_artifacts import NpmPushArtifacts
+from tests.helpers.test_utils import Any
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+from testfixtures import TempDirectory
+
+# @patch("ploigos_step_runner.step_implementers.shared.NpmGeneric.__init__")
+class TestStepImplementerNpmPushArtifacts___init__(BaseStepImplementerTestCase):
+    def test_defaults(self):
+
+        """ Assemble """
+        workflow_result = WorkflowResult()
+        parent_work_dir_path = '/fake/path'
+        step_config = {
+            "npm-registry": "https://werock.com",
+            "npm-user": "npm-user-name",
+            "npm-password": "npm-password"
+        }
+
+        """ Act """
+        step_implementer = self.create_given_step_implementer(
+            step_implementer=NpmPushArtifacts,
+            step_config=step_config,
+            step_name='push-artifacts',
+            implementer='NpmPushArtifacts',
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+        """ Assert """
+        self.assertIsNotNone(step_implementer)
+
+    def test_config_registry(self):
+        self.assertEqual(
+            NpmPushArtifacts._required_config_or_result_keys(),
+            [
+                'npm-registry',
+                'npm-user',
+                'npm-password'
+            ]
+        )
+
+    @patch('sh.npm', create=True)# Given a shell command, 'npm'
+    @patch('os.path.exists', side_effect=lambda filename: filename == 'package.json')# Given that a file named package.json exists
+    def test_run_publish_shell_command_successfully(self, os_path_exists_mock, npm_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an NpmTest step implementer that is configured to run 'npm install' before running the unit tests
+            npm_test = self.create_given_step_implementer(
+                NpmPushArtifacts,
+                step_config = {
+                    "npm-registry": "https://werock.com",
+                    "npm-user": "npm-user-name",
+                    "npm-password": "npm-password"
+                },
+                parent_work_dir_path=working_dir_path
+            )
+
+            # When I run the step
+            step_result = npm_test.run_step()
+
+            """ Assert """
+            # Then it should run the npm shell command with "publish" as the first argument
+            args, kwargs = npm_shell_command_mock.call_args
+            self.assertEqual(args[0], "publish") # first positional argument to sh.npm
+
+            self.assertTrue(step_result.success)
+
+    @patch('sh.npm', create=True, side_effect=StepRunnerException("Test Error"))
+    @patch('os.path.exists', side_effect=lambda filename: filename == 'package.json')
+    def test_run_publish_shell_command_with_error(self, os_path_exists_mock, npm_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an NpmTest step implementer that is configured to run 'npm install' before running the unit tests
+            npm_test = self.create_given_step_implementer(
+                NpmPushArtifacts,
+                step_config={
+                    "npm-registry": "https://werock.com",
+                    "npm-user": "npm-user-name",
+                    "npm-password": "npm-password"
+                },
+                parent_work_dir_path=working_dir_path
+            )
+
+            # When I run the step
+            step_result = npm_test.run_step()
+
+            """ Assert """
+            self.assertFalse(step_result.success)
+            expected_message = "NPM publish failure.  See 'npm_publish_output.txt' report artifacts for details: Test Error"
+            self.assertEqual(expected_message, step_result.message)
+
+    @patch('sh.npm', create=True)
+    @patch('os.path.exists', side_effect=lambda filename: filename == 'package.json')
+    def test_run_publish_shell_command_with_environment_vars(self, os_path_exists_mock, npm_shell_command_mock):
+
+        # Given a working directory
+        with TempDirectory() as temp_dir:
+            working_dir_path = os.path.join(temp_dir.path, 'working')
+
+            # Given an NpmTest step implementer that is configured to run 'npm install' before running the unit tests
+            npm_test = self.create_given_step_implementer(
+                NpmPushArtifacts,
+                step_config={
+                    "npm-registry": "https://werock.com",
+                    "npm-user": "npm-user-name",
+                    "npm-password": "npm-password"
+                },
+                parent_work_dir_path=working_dir_path
+            )
+
+            # When I run the step
+            npm_test.run_step()
+
+            """ Assert """
+            # Then it should run the npm shell command with environment variables like:
+            args, kwargs = npm_shell_command_mock.call_args
+            actual_env_args = kwargs['_env'] # environment vars passed to sh.npm
+            self.assertEqual(actual_env_args['NPM_CONFIG_REGISTRY'],"https://werock.com")
+
+            # Then the NPM_CONFIG__AUTH env variable should be the concatenated, base 64 encoded username & password.
+            # NOTE: .encode() does not base 64 encode. It just gets the bytes so they can be bassed to b64decode().
+            self.assertEqual(b64decode(actual_env_args['NPM_CONFIG__AUTH'].encode()), b'npm-user-name:npm-password') 
+
+"""
+Test Cases
+
+1) DONE - NpmPushArtifacts class can instantiate 
+2) DONE - NpmPushArtifacts is configured properly
+ - contains a valid config value for: NPM REGISTRY
+ - contains a valid config value for: NPM USER NAME 
+ - contains a valid config value for: NPM USER PASSWORD 
+ 2.a)  NpmPushArtifacts is configured improperly - No registry provided
+ 2.b)  NpmPushArtifacts is configured improperly - No user name
+ 2.c)  NpmPushArtifacts is configured improperly - No user password
+3) DONE - NpmPushArtifacts calls 'npm publish' successfully
+    CRITERIA - 
+    3.a) test that there is an npm_publish_outputs.txt file
+4) NpmPushArtifacts calls 'npm publish' and there is a failure
+    4.a) an execption message if provided and the step result success is false
+
+"""


### PR DESCRIPTION
# Purpose
Add support for npm for push-artifacts step

# Breaking?
No

# Integration Testing
https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(typical)/job/reference-nodejs-npm/view/change-requests/job/PR-1/

The integration test passes if we make it past CI: Package Application" step (still working on the remaining steps).