### PR TITLE
Fixed trailing slash issue

### DIFF
--- a/src/ploigos_step_runner/step_implementers/report/result_artifacts_archive.py
+++ b/src/ploigos_step_runner/step_implementers/report/result_artifacts_archive.py
@@ -55,6 +55,7 @@ Result Artifact Key              | Description
 import json
 import os
 import pprint
+import re
 import shutil
 
 from ploigos_step_runner import StepImplementer, StepResult
@@ -217,9 +218,10 @@ class ResultArtifactsArchive(StepImplementer):
                         if os.path.isfile(artifact.value):
                             shutil.copy(artifact.value, results_archive_artifact_dir_path)
                         elif os.path.isdir(artifact.value):
+                            basename = self.__basename_of_dir(artifact.value)
                             dest_path = os.path.join(
                                 results_archive_artifact_dir_path,
-                                os.path.basename(artifact.value)
+                                basename
                             )
                             shutil.copytree(artifact.value, dest_path)
                     else:
@@ -276,3 +278,13 @@ class ResultArtifactsArchive(StepImplementer):
             results_artifacts_archive = None
 
         return results_artifacts_archive
+
+    @staticmethod
+    def __basename_of_dir(absolute_path):
+        """
+        Returns the name of the directory without any parent directories or slashes.
+        __basename_of_dir('/foo/bar/') returns 'bar'.
+        This is useful because os.path.basename('/foo/bar/') returns ''.
+        """
+        no_trailing_slash = re.sub(f'{os.path.sep}$', '', absolute_path)
+        return os.path.basename(no_trailing_slash)

--- a/tests/step_implementers/report/test_result_artifacts_archive.py
+++ b/tests/step_implementers/report/test_result_artifacts_archive.py
@@ -425,7 +425,7 @@ class TestStepImplementerResultArtifactsArchive__create_archive(TestStepImplemen
             )
             step_result.add_artifact(
                 name='test-step-result-dir',
-                value=os.path.join(temp_dir.path, artifact_dir_name)
+                value=os.path.join(temp_dir.path, f'{artifact_dir_name}/')
             )
             workflow_result = WorkflowResult()
             workflow_result.add_step_result(step_result)


### PR DESCRIPTION
# Purpose

The report step was throwing errors if another step created an artifact with a value like '/path/to/directory/' that had the '/' at the end.

<!--
Please describe the purpose of this pull request.
If for an enhancment please go beyond just saying "adding fuctionality X" and add a reason/use case for the functionality.
-->

# Breaking?
No

# Integration Testing
https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-71/
https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-71/
https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(everything)/job/reference-quarkus-mvn/view/change-requests/job/PR-71/
