### PR TITLE
Fix: Add container auth file to get digest call for secured registries

### DIFF
--- a/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/skopeo.py
@@ -231,7 +231,8 @@ class Skopeo(StepImplementer):
             try:
                 print("Get pushed container image digest")
                 container_image_digest = get_container_image_digest(
-                    container_image_address=container_image_push_address_by_tag
+                    container_image_address=container_image_push_address_by_tag,
+                    containers_config_auth_file=containers_config_auth_file
                 )
 
                 container_image_short_address_by_digest = \


### PR DESCRIPTION
# Purpose

Current digest pull requests do not pass credentials so any calls to registries that are secured or don't allow anonymous pulls  fail. The existing digest image get method support passing an auth file but it was not implemented in the call. Added the existing auth config file used for pushing to the method call so it will also be used for pulls.

# Breaking?
No

# Integration Testing
* [Everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28everything%29/job/reference-quarkus-mvn/job/PR-73/1/display/redirect)
* [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28typical%29/job/reference-quarkus-mvn/job/PR-73/1/display/redirect)
* [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28minimal%29/job/reference-quarkus-mvn/job/PR-73/1/display/redirect)
