### PR TITLE
Enhance xunit test report format support

### DIFF
--- a/src/ploigos_step_runner/utils/xml.py
+++ b/src/ploigos_step_runner/utils/xml.py
@@ -21,6 +21,36 @@ def get_xml_element(xml_file, element_name):
         The Element matching the given element_name.
     """
 
+    xml_element = get_xml_element_if_present(xml_file, element_name)
+
+    # verify information from xml file
+    if xml_element is None:
+        raise ValueError('Given xml file (' + \
+             xml_file + \
+             ') does not have ./' + \
+             element_name + \
+             ' element' \
+        )
+
+    return xml_element
+
+
+def get_xml_element_if_present(xml_file, element_name):
+    """ Gets a given element from a given xml file, if the xml file has that element.
+        Otherwise returns None.
+
+    Raises
+    ------
+    ValueError
+        If the given xml_file does not exist.
+
+    Returns
+    -------
+    xml.etree.ElementTree.Element
+        The Element matching the given element_name.
+        Or None if the file does not contain an Element with element_name.
+    """
+
     # verify runtime config
     if not os.path.exists(xml_file):
         raise ValueError('Given xml file does not exist: ' + xml_file)
@@ -38,15 +68,6 @@ def get_xml_element(xml_file, element_name):
         xml_element = xml_root
     else:
         xml_element = xml_root.find('./' + xml_namespace + element_name)
-
-    # verify information from xml file
-    if xml_element is None:
-        raise ValueError('Given xml file (' + \
-             xml_file + \
-             ') does not have ./' + \
-             element_name + \
-             ' element' \
-        )
 
     return xml_element
 

--- a/tests/step_implementers/shared/test_maven_test_reporting_mixin.py
+++ b/tests/step_implementers/shared/test_maven_test_reporting_mixin.py
@@ -213,7 +213,7 @@ class TestMavenTestReportingMixin__gather_evidence_from_test_report_directory_te
                 test_report_dirs=[test_report_dir]
             )
 
-    def test_found_dir_found_no_attributes(self, mock_collect_report_results):
+    def test_found_dir_found_some_attributes(self, mock_collect_report_results):
         with TempDirectory() as test_dir:
             # setup test
             actual_step_result = StepResult(
@@ -249,18 +249,17 @@ class TestMavenTestReportingMixin__gather_evidence_from_test_report_directory_te
             )
             expected_step_result.add_evidence(name='time', value=1.42)
             expected_step_result.add_evidence(name='tests', value=42)
-            test_report_evidence_element = 'testsuite'
-            not_found_attribs = ["errors", "skipped", "failures"]
+            not_found_attribs = ["failures"]
             expected_step_result.message += "\nWARNING: could not find expected evidence" \
-                f" attributes ({not_found_attribs}) on xml element" \
-                f" ({test_report_evidence_element}) in test report" \
+                f" attributes ({not_found_attribs}) on a recognized xml root element" \
+                f" (['testsuites', 'testsuite']) in test report" \
                 f" directory (['{test_report_dir}'])."
             self.assertEqual(actual_step_result, expected_step_result)
             mock_collect_report_results.assert_called_once_with(
                 test_report_dirs=[test_report_dir]
             )
 
-    def test_found_dir_found_some_attributes(self, mock_collect_report_results):
+    def test_found_dir_found_no_attributes(self, mock_collect_report_results):
         with TempDirectory() as test_dir:
             # setup test
             actual_step_result = StepResult(
@@ -291,11 +290,10 @@ class TestMavenTestReportingMixin__gather_evidence_from_test_report_directory_te
                 sub_step_name='mock-maven-test-sub-step',
                 sub_step_implementer_name='MockMavenTestReportingMixinStepImplementer'
             )
-            test_report_evidence_element = 'testsuite'
-            not_found_attribs = ["time", "tests", "errors", "skipped", "failures"]
+            not_found_attribs = ["time", "tests", "failures"]
             expected_step_result.message += "\nWARNING: could not find expected evidence" \
-                f" attributes ({not_found_attribs}) on xml element" \
-                f" ({test_report_evidence_element}) in test report" \
+                f" attributes ({not_found_attribs}) on a recognized xml root element" \
+                f" (['testsuites', 'testsuite']) in test report" \
                 f" directory (['{test_report_dir}'])."
             self.assertEqual(actual_step_result, expected_step_result)
             mock_collect_report_results.assert_called_once_with(
@@ -334,8 +332,8 @@ class TestMavenTestReportingMixin__gather_evidence_from_test_report_directory_te
                 sub_step_implementer_name='MockMavenTestReportingMixinStepImplementer'
             )
             expected_step_result.message += "\nWARNING: could not find expected evidence" \
-                " attributes (['time', 'tests', 'errors', 'skipped', 'failures'])" \
-                f" on xml element (testsuite) in test report directory (['{test_report_dir}'])."
+                " attributes (['time', 'tests', 'failures'])" \
+                f" on a recognized xml root element (['testsuites', 'testsuite']) in test report directory (['{test_report_dir}'])."
             self.assertEqual(actual_step_result, expected_step_result)
             mock_collect_report_results.assert_called_once_with(
                 test_report_dirs=[test_report_dir]

--- a/tests/utils/test_xml.py
+++ b/tests/utils/test_xml.py
@@ -81,6 +81,33 @@ class TestXMLUtils_other(BaseTestCase):
 
                 get_xml_element(pom_file_path, 'does-not-exist')
 
+class TestXMLUtils_get_xml_element_if_present(BaseTestCase):
+    def test_gets_element(self):
+        """Test getting an xml element."""
+        with TempDirectory() as temp_dir:
+            file = b'''<baseelement>
+                            <child>my-value</child>
+                        </baseelement>'''
+            temp_dir.write('file.xml', file)
+            file_path = path.join(temp_dir.path, 'file.xml')
+
+            actual_value = get_xml_element_if_present(file_path, 'child').text
+
+            self.assertEqual('my-value', actual_value)
+
+    def test_returns_none_for_nonexistent_element(self):
+        """Test getting an xml element."""
+        with TempDirectory() as temp_dir:
+            file = b'''<baseelement>
+                            <child>my-value</child>
+                        </baseelement>'''
+            temp_dir.write('file.xml', file)
+            file_path = path.join(temp_dir.path, 'file.xml')
+
+            actual_element = get_xml_element_if_present(file_path, 'not-present')
+
+            self.assertEqual(None, actual_element)
+
 class TestXMLUtils_get_xml_element_by_path(BaseTestCase):
     def test_none_existent_file(self):
         """Test get xml element by xpath but file does not exist."""

--- a/tests/utils/test_xml.py
+++ b/tests/utils/test_xml.py
@@ -108,6 +108,20 @@ class TestXMLUtils_get_xml_element_if_present(BaseTestCase):
 
             self.assertEqual(None, actual_element)
 
+    def test_returns_first_of_two_elements(self):
+        """Test getting an xml element."""
+        with TempDirectory() as temp_dir:
+            file = b'''<baseelement>
+                            <child1>value1</child1>
+                            <child2>value2</child2>
+                        </baseelement>'''
+            temp_dir.write('file.xml', file)
+            file_path = path.join(temp_dir.path, 'file.xml')
+
+            actual_value = get_xml_element_if_present(file_path, 'child1').text
+
+            self.assertEqual('value1', actual_value)
+
 class TestXMLUtils_get_xml_element_by_path(BaseTestCase):
     def test_none_existent_file(self):
         """Test get xml element by xpath but file does not exist."""


### PR DESCRIPTION
# Purpose
Ploigos understands the xml format produced by junit and some similar xunit test reporters. But not every xunit reporter or test suite produces exactly the same xml. This PR broadens the range of xunit xml that Ploigos understands in two ways.
1. It supports output xml that wraps multiple <testsuite/> elements in a root <testsuites/> element.
2. It supports output xml that does not explicitly report error or skipped counts when there are no errors or skipped tests. We now assume that the counts are 0 if missing because that is how some reporters (cypress+mocha) behave.

# Breaking?
No

# Integration Testing
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
* [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/blue/organizations/jenkins/Ploigos%20Reference%20Applciations%20(typical)%2Freference-nodejs-npm/detail/PR-1/108/pipeline)
(Minimal is not relevant and Everything does not yet work for JavaScript.)
