### PR TITLE
Making generate metadata results and config more clear.

### DIFF
--- a/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
@@ -49,7 +49,7 @@ Result Artifact Key | Description
 `branch`            | Current branch name.
 `is-pre-release`    | `True` if this build should be considered a pre-release, \
                       `False` if should be considered a release.
-`sha`               | Current commit sha.
+`commit-hash`       | Current commit hash.
 """# pylint: disable=line-too-long
 
 import re
@@ -199,11 +199,11 @@ class Git(StepImplementer, GitMixin):  # pylint: disable=too-few-public-methods
                 step_result.message = f"Error committing and pushing changes: {error}"
                 return step_result
 
-        # add commit sha artifact
+        # add commit hash artifact
         try:
             git_branch_last_commit_sha = str(repo.head.reference.commit)
             step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value=git_branch_last_commit_sha
             )
         except ValueError:

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/semantic_version.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/semantic_version.py
@@ -50,22 +50,22 @@ Configuration Key                       | Required? | Default | Description
 `workflow-run-num`                      | No        |         | If `is-pre-release` is `True`, value to use for a numeric identifier of the branch `pre-release` identifier if provided. \
                                                                 Also always used in build identifier. \
                                                                 Since this can be included in the pre-release section, it should be incremental as per the sem version spec.
-                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<sha>.<workflow-run-num>` <br/>\
-                                                                EX (release): `<app-version>+<sha>.<workflow-run-num>`
-`sha`                                   | No        |         | Value to use for sha build identifier in build portion of semantic version. \
-                                                                EX: `<app-version>+<sha>`
-`sha-build-identifier-length`           | No        | 7       | Trim the given `sha` down to this length when including as build identifier in semantic version
+                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<commit-hash>.<workflow-run-num>` <br/>\
+                                                                EX (release): `<app-version>+<commit-hash>.<workflow-run-num>`
+`commit-hash`                           | No        |         | Value to use for commit hash build identifier in build portion of semantic version. \
+                                                                EX: `<app-version>+<commit-hash>`
+`commit-hash-build-identifier-length`   | No        | 7       | Trim the given `commit-hash` down to this length when including as build identifier in semantic version
 `additional-pre-release-identifiers`    | No        |         | If `is-pre-release` is `True`, additional `pre-release` identifiers to add to semantic version (https://semver.org/). \
                                                                 Ignored if `is-pre-release` is `False. \
-                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>-<additional-pre-release-identifiers>+<sha>.<workflow-run-num>`
+                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>-<additional-pre-release-identifiers>+<commit-hash>.<workflow-run-num>`
 `additional-build-identifiers`          | No        |         | Additional `build` identifiers to add to semantic version (https://semver.org/). \
-                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<sha>.<workflow-run-num>.<additional-build-identifiers>` <br/>\
-                                                                EX (release): `<app-version>+<sha>.<workflow-run-num>.<additional-build-identifiers>`
-`container-image-tag-build-deliminator` | Yes       | `_`   | Unfortunately the container image tag spec does not allow for the `+` character which means can not follow \
-                                                              strict semver syntax when including the `build` portion of the semver in the image tag. \
-                                                              The value here is used instead of the `+` for the purposes of container image tags. \
-                                                              NOTE: the default `_` is chosen because it is otherwise not a valid character in semver syntax so if doing parsing \
-                                                              against the standard semver spec/regex it is simple enough to swap the `+` for a `_` and still get accurate results.
+                                                                EX (pre-release): `<app-version>-<branch>.<workflow-run-num>+<commit-hash>.<workflow-run-num>.<additional-build-identifiers>` <br/>\
+                                                                EX (release): `<app-version>+<commit-hash>.<workflow-run-num>.<additional-build-identifiers>`
+`container-image-tag-build-deliminator` | Yes       | `_`     | Unfortunately the container image tag spec does not allow for the `+` character which means can not follow \
+                                                                strict semver syntax when including the `build` portion of the semver in the image tag. \
+                                                                The value here is used instead of the `+` for the purposes of container image tags. \
+                                                                NOTE: the default `_` is chosen because it is otherwise not a valid character in semver syntax so if doing parsing \
+                                                                against the standard semver spec/regex it is simple enough to swap the `+` for a `_` and still get accurate results.
 
 Result Artifacts
 ----------------
@@ -88,7 +88,7 @@ from ploigos_step_runner.results import StepResult
 
 DEFAULT_CONFIG = {
   'is-pre-release': False,
-  'sha-build-identifier-length': 7,
+  'commit-hash-build-identifier-length': 7,
   'container-image-tag-build-deliminator': '_'
 }
 
@@ -255,16 +255,16 @@ class SemanticVersion(StepImplementer):  # pylint: disable=too-few-public-method
         build = None
         build_identifiers = []
 
-        # if sha given add as a build identifier
-        sha = self.get_value('sha')
-        if sha:
-            sha_build_identifier = None
-            sha_build_identifier_length = self.get_value('sha-build-identifier-length')
-            if sha_build_identifier_length:
-                sha_build_identifier = str(sha)[:sha_build_identifier_length]
+        # if commit-hash given add as a build identifier
+        commit_hash = self.get_value('commit-hash')
+        if commit_hash:
+            commit_hash_build_identifier = None
+            commit_hash_build_identifier_length = self.get_value('commit-hash-build-identifier-length')
+            if commit_hash_build_identifier_length:
+                commit_hash_build_identifier = str(commit_hash)[:commit_hash_build_identifier_length]
             else:
-                sha_build_identifier = sha
-            build_identifiers.append(sha_build_identifier)
+                commit_hash_build_identifier = commit_hash
+            build_identifiers.append(commit_hash_build_identifier)
 
         # if workflow run num given as a build identifier
         workflow_run_num = self.get_value('workflow-run-num')

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -100,7 +100,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=False
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -153,7 +153,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -207,7 +207,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -260,7 +260,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=False
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -306,7 +306,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=False
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -350,7 +350,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=False
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -393,7 +393,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -439,7 +439,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -483,7 +483,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 
@@ -527,7 +527,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 value=True
             )
             expected_step_result.add_artifact(
-                name='sha',
+                name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
 

--- a/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_semantic_version_generate_metadata.py
@@ -35,7 +35,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata_misc(
         defaults = SemanticVersion.step_implementer_config_defaults()
         expected_defaults = {
             'is-pre-release': False,
-            'sha-build-identifier-length': 7,
+            'commit-hash-build-identifier-length': 7,
             'container-image-tag-build-deliminator': '_'
         }
         self.assertEqual(defaults, expected_defaults)
@@ -555,7 +555,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_
     def test_only_sha_default_length(self):
         # setup
         step_config = {
-            'sha': 'a1b2c3d4e5f6g7h8i9'
+            'commit-hash': 'a1b2c3d4e5f6g7h8i9'
         }
         step_implementer = self.create_step_implementer(
             step_config=step_config,
@@ -572,8 +572,8 @@ class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_
     def test_only_sha_custom_length(self):
         # setup
         step_config = {
-            'sha': 'a1b2c3d4e5f6g7h8i9',
-            'sha-build-identifier-length': 10
+            'commit-hash': 'a1b2c3d4e5f6g7h8i9',
+            'commit-hash-build-identifier-length': 10
         }
         step_implementer = self.create_step_implementer(
             step_config=step_config,
@@ -590,8 +590,8 @@ class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_
     def test_only_sha_no_length(self):
         # setup
         step_config = {
-            'sha': 'a1b2c3d4e5f6g7h8i9',
-            'sha-build-identifier-length': None
+            'commit-hash': 'a1b2c3d4e5f6g7h8i9',
+            'commit-hash-build-identifier-length': None
         }
         step_implementer = self.create_step_implementer(
             step_config=step_config,
@@ -662,7 +662,7 @@ class TestStepImplementerSemanticVersionGenerateMetadata___get_semantic_version_
     def test_sha_workflow_run_num_additional_build_identifiers_list(self):
         # setup
         step_config = {
-            'sha': 'a1b2c3d4e5f6g7h8i9',
+            'commit-hash': 'a1b2c3d4e5f6g7h8i9',
             'workflow-run-num': 42,
             'additional-build-identifiers': [
                 'mock3',


### PR DESCRIPTION
# Purpose
Making generate metadata results and config more clear.

# Breaking?
Yes

## Whats Breaking and why?

Making this change because when working on another step implementer that needs to use the commit hash realized that the config value `sha` was not very clear and that `commit-hash` is much more self explanitory. 

While this config is exposed externally the use case for anyone setting directly is slim and is really just used internally between sub step so the chance of breaking anyone is low to none.

generate-metadata/git:
* result 'sha' to 'commit-hash'
generate-metadata/semantic-version:
* config 'sha' to 'commit-hash'
* config 'sha-build-identifier-length' to 'commit-hash-build-identifier-length'

# Integration Testing
* [Minimal - TODO](TODO)
