### PR TITLE
Openscap severity

### DIFF
--- a/src/ploigos_step_runner/step_implementers/container_image_static_vulnerability_scan/openscap.py
+++ b/src/ploigos_step_runner/step_implementers/container_image_static_vulnerability_scan/openscap.py
@@ -33,6 +33,12 @@ Could come from:
                                                        remote resources and this is not True. \
                                                        For disconnected environments the remote \
                                                        internal mirror.
+'oscap-severity'               | No        |         | Severity threshold for failing a step. \
+                                                       Will fail step on any vulnerability at \
+                                                       that severity or higher.. Will fail on \
+                                                       any severity if unset. \
+                                                       Valid severity: \
+                                                       low|moderate|important|critical \
 `[container-image-pull-registry-type, container-image-registry-type]` \
                                | Yes       | 'containers-storage:' \
                                                      | \


### PR DESCRIPTION
# Purpose

Adds the ability to set severity threshold for OpenSCAP XCCDF evaluations durring container-image-static-vulnerability-scan to allow any failed evaluations that fall below the user set threshold to be noted in the build logs but not fail the build.

# Breaking?
No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing

Everything fails due to a failure in the OpenSCAP Static Image Scan. This is unrelated to the changes in the PR.

* [Everything](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28everything%29/job/reference-quarkus-mvn/job/PR-73/3/display/redirect)
* [Typical](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28typical%29/job/reference-quarkus-mvn/job/PR-73/3/display/redirect)
* [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20%28minimal%29/job/reference-quarkus-mvn/job/PR-73/3/display/redirect)
