### PR TITLE
Feature/pelorus

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
   gitpython
   sh
   jinja2
+  prometheus_client
 
 [options.packages.find]
 where=src

--- a/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
+++ b/src/ploigos_step_runner/step_implementers/generate_metadata/git.py
@@ -44,12 +44,13 @@ Result Artifacts
 ----------------
 Results artifacts output by this step.
 
-Result Artifact Key | Description
---------------------|------------
-`branch`            | Current branch name.
-`is-pre-release`    | `True` if this build should be considered a pre-release, \
-                      `False` if should be considered a release.
-`commit-hash`       | Current commit hash.
+Result Artifact Key    | Description
+-----------------------|------------
+`branch`               | Current branch name.
+`is-pre-release`       | `True` if this build should be considered a pre-release, \
+                         `False` if should be considered a release.
+`commit-hash`          | Current commit hash.
+`commit-utc-timestamp` | Current commit UTC POSIX timestamp.
 """# pylint: disable=line-too-long
 
 import re
@@ -211,6 +212,12 @@ class Git(StepImplementer, GitMixin):  # pylint: disable=too-few-public-methods
             step_result.message = f'Given Git repository root is a' \
                 f' git branch ({git_branch}) with no commit history.'
             return step_result
+
+        # add commit timestamp
+        step_result.add_artifact(
+            name='commit-utc-timestamp',
+            value=self.git_commit_utc_timestamp()
+        )
 
         return step_result
 

--- a/src/ploigos_step_runner/step_implementers/push_container_image/__init__.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/__init__.py
@@ -1,4 +1,7 @@
 """`StepImplementers` for the `push-container-image` step.
-"""
+"""# pylint: disable=line-too-long
 
-from ploigos_step_runner.step_implementers.push_container_image.skopeo import Skopeo
+from ploigos_step_runner.step_implementers.push_container_image.pelorus_commit_timestamp_metric import \
+    PelorusCommitTimestampMetric
+from ploigos_step_runner.step_implementers.push_container_image.skopeo import \
+    Skopeo

--- a/src/ploigos_step_runner/step_implementers/push_container_image/pelorus_commit_timestamp_metric.py
+++ b/src/ploigos_step_runner/step_implementers/push_container_image/pelorus_commit_timestamp_metric.py
@@ -1,0 +1,221 @@
+"""`StepImplementer` to extend the `push-container-image` step to push the
+Pelorus Commit Timestamp metric to a Prometheus Pushgateway inlieuof the default
+Pelorus Commit Timestamp exporter which depends on OpenShift BuildConfigs.
+
+Step Configuration
+------------------
+Step configuration expected as input to this step.
+Could come from:
+
+  * static configuration
+  * runtime configuration
+  * previous step results
+
+Configuration Key                    | Required? | Default | Description
+-------------------------------------|-----------|---------|-----------
+`commit-hash`                        | Yes       |         | Current commit hash.
+`commit-utc-timestamp`               | Yes       |         | Current commit UTC POSIX timestamp.
+`container-image-push-digest`        | Yes       |         | Container image digest of pushed container image. \
+                                                             IMPORTANT: this must be the image digest as calculated for the image \
+                                                             as reported by the image registry it is pushed to as it must match \
+                                                             the image digest used for deployment.
+`container-image-digest`             | Yes       |         | Alias for `container-image-push-digest`.
+`pelorus-prometheus-pushgateway-url` | Yes       |         | URL to Prometheus Pushgateway that Pelorus is configured to read from.
+`pelorus-prometheus-job`             | Yes       | ploigos | Prometheus Job that the pushed metric should be reported from.
+`pelorus-app-name`                   | Yes       |         | The name by which Pelorus knows this system component by. \
+                                                             This must align with the app name that the Deploy Time exporter knows \
+                                                             this system component by. By default the Pelorus Deploy Time exporter \
+                                                             uses the value of the `app.kubernetes.io/name` label on the deployed Pod \
+                                                             but this is configurable in Pelorus, see the Pelorus documentation \
+                                                             https://github.com/konveyor/pelorus/tree/master/exporters/deploytime#supported-integrations.
+
+Result Artifacts
+----------------
+Results artifacts output by this step.
+
+None.
+
+"""# pylint: disable=line-too-long
+
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
+from ploigos_step_runner.results import StepResult
+from ploigos_step_runner.step_implementer import StepImplementer
+
+DEFAULT_CONFIG = {
+    'pelorus-prometheus-job': 'ploigos'
+}
+
+REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS = [
+    'commit-hash',
+    'commit-utc-timestamp',
+    ['container-image-push-digest', 'container-image-digest'],
+    'pelorus-prometheus-pushgateway-url',
+    'pelorus-prometheus-job',
+    'pelorus-app-name'
+]
+
+class PelorusCommitTimestampMetric(StepImplementer):
+    """`StepImplementer` to extend the `push-container-image` step to push the
+    Pelorus Commit Timestamp metric to a Prometheus Pushgateway inlieuof the default
+    Pelorus Commit Timestamp exporter which depends on OpenShift BuildConfigs.
+    """
+
+    @staticmethod
+    def step_implementer_config_defaults():
+        """Getter for the StepImplementer's configuration defaults.
+
+        Notes
+        -----
+        These are the lowest precedence configuration values.
+
+        Returns
+        -------
+        dict
+            Default values to use for step configuration values.
+        """
+        return DEFAULT_CONFIG
+
+    @staticmethod
+    def _required_config_or_result_keys():
+        """Getter for step configuration or previous step result artifacts that are required before
+        running this step.
+
+        See Also
+        --------
+        _validate_required_config_or_previous_step_result_artifact_keys
+
+        Returns
+        -------
+        array_list
+            Array of configuration keys or previous step result artifacts
+            that are required before running the step.
+        """
+        return REQUIRED_CONFIG_OR_PREVIOUS_STEP_RESULT_ARTIFACT_KEYS
+
+    def _validate_required_config_or_previous_step_result_artifact_keys(self):
+        """Validates that the required configuration keys or previous step result artifacts
+        are set and have valid values.
+
+        Validates that:
+        * required configuration is given
+        * given 'pelorus-app-name' is equal to or less then 63 characters
+
+        Raises
+        ------
+        AssertionError
+            If step configuration or previous step result artifacts have invalid required values
+        """
+        super()._validate_required_config_or_previous_step_result_artifact_keys()
+
+        assert len(self.pelorus_app_name) <= 63, \
+            f"Given Pelorus Application Name ({self.pelorus_app_name}) is invalid because it is" \
+            " longer than 63 characters which because it is expected to be a" \
+            " kubernetes label value breaks the kubernetes label value length rules." \
+            " https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set"
+
+    @property
+    def commit_hash(self):
+        """
+        Returns
+        -------
+        str
+            Current commit hash.
+        """
+        return self.get_value('commit-hash')
+
+    @property
+    def commit_utc_timestamp(self):
+        """
+        Returns
+        -------
+        str
+            Current commit UTC POSIX timestamp.
+        """
+        return self.get_value('commit-utc-timestamp')
+
+    @property
+    def container_image_digest(self):
+        """
+        Returns
+        -------
+        str
+            Container image digest of pushed container image.
+        """
+        return self.get_value(['container-image-push-digest', 'container-image-digest'])
+
+    @property
+    def pelorus_prometheus_pushgateway_url(self):
+        """
+        Returns
+        -------
+        str
+            URL to Prometheus Pushgateway that Pelorus is configured to read from.
+        """
+        return self.get_value('pelorus-prometheus-pushgateway-url')
+
+    @property
+    def pelorus_prometheus_job(self):
+        """
+        Returns
+        -------
+        str
+            Prometheus Job that the pushed metric should be reported from.
+        """
+        return self.get_value('pelorus-prometheus-job')
+
+    @property
+    def pelorus_app_name(self):
+        """
+        Returns
+        -------
+        str
+            The name by which Pelorus knows this system component by.
+        """
+        return self.get_value('pelorus-app-name')
+
+    def _run_step(self):
+        """Runs the step implemented by this StepImplementer.
+
+        Returns
+        -------
+        StepResult
+            Object containing the dictionary results of this step.
+        """
+        step_result = StepResult.from_step_implementer(self)
+
+        # create the gauge
+        registry = CollectorRegistry()
+        gauge = Gauge(
+            name='commit_timestamp',
+            documentation='Pelorus Software Delivery Performance (SDP) Commit timestamp.' \
+                'https://github.com/konveyor/pelorus/blob/master/exporters/committime/README.md#commit-time-exporter',
+            registry=registry,
+            labelnames=['app', 'commit', 'image_sha']
+        )
+
+        # set the value and its labels
+        gauge.labels(
+            app=self.pelorus_app_name,
+            commit=self.commit_hash,
+            image_sha=self.container_image_digest
+        ).set(self.commit_utc_timestamp)
+
+        # push to prometheus pushgateway
+        try:
+            push_to_gateway(
+                gateway=self.pelorus_prometheus_pushgateway_url,
+                job=self.pelorus_prometheus_job,
+                grouping_key={
+                    'job': self.pelorus_prometheus_job,
+                    'app': self.pelorus_app_name,
+                    'commit': self.commit_hash
+                },
+                registry=registry
+            )
+        except Exception as error: # pylint: disable=broad-except
+            step_result.success = False
+            step_result.message = "Error pushing Pelorus Commit Timestamp metric to" \
+                f" Prometheus Pushgateway ({self.pelorus_prometheus_pushgateway_url}): {error}"
+
+        return step_result

--- a/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
+++ b/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
@@ -30,6 +30,7 @@ Configuration Key    | Required? | Default              | Description
                                                         | Git commit message to use when/if creating an automated git commit.
 """# pylint: disable=line-too-long
 
+from datetime import timezone
 from urllib.parse import urlsplit, urlunsplit
 
 from git import InvalidGitRepositoryError, Repo
@@ -329,3 +330,16 @@ class GitMixin:
             raise StepRunnerException(
                 f"Error creating git tag ({git_tag_value}): {error}"
             ) from error
+
+    def git_commit_utc_timestamp(self):
+        """Get the Git commit UTC timestamp.
+
+        Returns
+        -------
+        str
+            Git commit POSIX timestamp in UTC timezone.
+        """
+        commit_datetime = self.git_repo.commit().committed_datetime
+        commit_utc_timestamp = commit_datetime.astimezone(tz=timezone.utc).timestamp()
+
+        return commit_utc_timestamp

--- a/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
+++ b/tests/step_implementers/generate_metadata/test_git_generate_metadata.py
@@ -62,9 +62,16 @@ class TestStepImplementerGitGenerateMetadata_misc(TestStepImplementerGitGenerate
         self.assertEqual(required_keys, expected_required_keys)
 
 
+@patch.object(Git, 'git_commit_utc_timestamp')
+@patch.object(Git, 'git_url', new_callable=PropertyMock)
+@patch.object(Git, 'git_repo', new_callable=PropertyMock)
 class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGenerateMetadataBase):
-    @patch.object(Git, 'git_repo')
-    def test_success_release_branch_default_release_branch_regexes(self, mock_repo):
+    def test_success_release_branch_default_release_branch_regexes(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -77,10 +84,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'main'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'main'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -103,15 +111,18 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_url', new_callable=PropertyMock)
-    @patch.object(Git, 'git_repo')
     def test_success_release_branch_default_prerelease_branch_regexes_commit_and_push_always(
-            self,
-            mock_repo,
-            git_url_mock
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
     ):
         # Test data setup
         branch_name = "not-main"
@@ -129,11 +140,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = branch_name
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
-            git_url_mock.return_value = "value doesn't matter"
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = branch_name
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_url.return_value = "value doesn't matter"
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -156,15 +168,18 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_url', new_callable=PropertyMock)
-    @patch.object(Git, 'git_repo')
     def test_success_release_branch_default_prerelease_branch_regexes_commit_and_push_always_not_dirty(
-            self,
-            mock_repo,
-            git_url_mock
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
     ):
         # Test data setup
         branch_name = "not-main"
@@ -182,12 +197,13 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.is_dirty.return_value = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = branch_name
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
-            git_url_mock.return_value = "value doesn't matter"
+            mock_repo().bare = False
+            mock_repo().is_dirty.return_value = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = branch_name
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_url.return_value = "value doesn't matter"
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -210,15 +226,18 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_url', new_callable=PropertyMock)
-    @patch.object(Git, 'git_repo')
     def test_success_release_branch_default_release_branch_regexes_commit_and_push_always(
-            self,
-            mock_repo,
-            git_url_mock
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
     ):
         # Test data setup
         branch_name = "main"
@@ -236,11 +255,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = branch_name
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
-            git_url_mock.return_value = "value doesn't matter"
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = branch_name
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_url.return_value = "value doesn't matter"
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -263,11 +283,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_release_branch_custom_release_branch_regexes_list(self, mock_repo):
+    def test_success_release_branch_custom_release_branch_regexes_list(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -283,10 +311,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'release/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'release/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -309,11 +338,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_release_branch_custom_release_branch_regexes_string(self, mock_repo):
+    def test_success_release_branch_custom_release_branch_regexes_string(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -327,10 +364,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'release/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'release/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -353,11 +391,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_pre_release_branch_default_release_branch_regexes(self, mock_repo):
+    def test_success_pre_release_branch_default_release_branch_regexes(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -370,10 +416,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'feature/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -396,11 +443,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_pre_release_branch_custom_release_branch_regexes_list(self, mock_repo):
+    def test_success_pre_release_branch_custom_release_branch_regexes_list(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -416,10 +471,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'feature/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -442,11 +498,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_pre_release_branch_custom_release_branch_regexes_string(self, mock_repo):
+    def test_success_pre_release_branch_custom_release_branch_regexes_string(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -460,10 +524,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'feature/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -486,11 +551,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_success_pre_release_branch_custom_release_branch_regexes_empty(self, mock_repo):
+    def test_success_pre_release_branch_custom_release_branch_regexes_empty(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -504,10 +577,11 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = 'feature/mock1'
-            mock_repo.head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = 'feature/mock1'
+            mock_repo().head.reference.commit = 'a1b2c3d4e5f6g7h8i9'
+            mock_git_commit_utc_timestamp.return_value = '42'
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -530,11 +604,19 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
                 name='commit-hash',
                 value='a1b2c3d4e5f6g7h8i9'
             )
+            expected_step_result.add_artifact(
+                name='commit-utc-timestamp',
+                value='42'
+            )
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo', new_callable=PropertyMock)
-    def test_fail_getting_git_repo(self, mock_git_repo):
+    def test_fail_getting_git_repo(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -547,7 +629,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_git_repo.side_effect = StepRunnerException('mock error')
+            mock_repo.side_effect = StepRunnerException('mock error')
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -563,8 +645,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_fail_git_repo_bare(self, mock_repo):
+    def test_fail_git_repo_bare(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -577,7 +663,7 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = True
+            mock_repo().bare = True
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -593,8 +679,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_fail_is_detached(self, mock_repo):
+    def test_fail_is_detached(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         with TempDirectory() as temp_dir:
             # setup
             step_config = {
@@ -607,8 +697,8 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = True
+            mock_repo().bare = False
+            mock_repo().head.is_detached = True
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -625,8 +715,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_fail_no_commit_history(self, mock_repo):
+    def test_fail_no_commit_history(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         # Data setup
         git_branch = 'main'
 
@@ -642,10 +736,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = git_branch
-            type(mock_repo.head.reference).commit = PropertyMock(side_effect=ValueError)
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = git_branch
+            type(mock_repo().head.reference).commit = PropertyMock(side_effect=ValueError)
 
             # run test
             actual_step_result = step_implementer._run_step()
@@ -670,8 +764,12 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
 
             self.assertEqual(actual_step_result, expected_step_result)
 
-    @patch.object(Git, 'git_repo')
-    def test_run_step_fail_commit_changes_and_push(self, mock_repo):
+    def test_run_step_fail_commit_changes_and_push(
+        self,
+        mock_repo,
+        mock_git_url,
+        mock_git_commit_utc_timestamp
+    ):
         # Data setup
         git_branch = 'main'
         error = 'Holy guacamole..!'
@@ -689,10 +787,10 @@ class TestStepImplementerGitGenerateMetadata_run_step(TestStepImplementerGitGene
             )
 
             # setup mocks
-            mock_repo.bare = False
-            mock_repo.head.is_detached = False
-            mock_repo.active_branch.name = git_branch
-            mock_repo.git.commit.side_effect = Exception(error)
+            mock_repo().bare = False
+            mock_repo().head.is_detached = False
+            mock_repo().active_branch.name = git_branch
+            mock_repo().git.commit.side_effect = Exception(error)
 
             # run test
             actual_step_result = step_implementer._run_step()

--- a/tests/step_implementers/push_container_image/test_pelorus_commit_timestamp_metric.py
+++ b/tests/step_implementers/push_container_image/test_pelorus_commit_timestamp_metric.py
@@ -1,0 +1,286 @@
+import unittest
+from unittest.mock import ANY, PropertyMock, patch
+
+from ploigos_step_runner.results import StepResult
+from ploigos_step_runner.step_implementer import StepImplementer
+from ploigos_step_runner.step_implementers.push_container_image.pelorus_commit_timestamp_metric import \
+    PelorusCommitTimestampMetric
+from tests.helpers.base_step_implementer_test_case import \
+    BaseStepImplementerTestCase
+
+
+class TestPelorusCommitTimestampMetricBase(BaseStepImplementerTestCase):
+    def create_step_implementer(
+            self,
+            step_config={},
+            workflow_result=None,
+            parent_work_dir_path=''
+    ):
+        return self.create_given_step_implementer(
+            step_implementer=PelorusCommitTimestampMetric,
+            step_config=step_config,
+            step_name='push-container-image',
+            implementer='PelorusCommitTimestampMetric',
+            workflow_result=workflow_result,
+            parent_work_dir_path=parent_work_dir_path
+        )
+
+class TestPelorusCommitTimestampMetric_step_implementer_config_defaults(
+    unittest.TestCase
+):
+    def test_result(self):
+        defaults = PelorusCommitTimestampMetric.step_implementer_config_defaults()
+        expected_defaults = {
+            'pelorus-prometheus-job': 'ploigos'
+        }
+        self.assertEqual(defaults, expected_defaults)
+
+class TestPelorusCommitTimestampMetric_required_config_or_result_keys(
+    unittest.TestCase
+):
+    def test_result(self):
+        required_keys = PelorusCommitTimestampMetric._required_config_or_result_keys()
+        expected_required_keys = [
+            'commit-hash',
+            'commit-utc-timestamp',
+            ['container-image-push-digest', 'container-image-digest'],
+            'pelorus-prometheus-pushgateway-url',
+            'pelorus-prometheus-job',
+            'pelorus-app-name'
+        ]
+        self.assertEqual(required_keys, expected_required_keys)
+
+@patch.object(StepImplementer, '_validate_required_config_or_previous_step_result_artifact_keys')
+@patch.object(PelorusCommitTimestampMetric, 'pelorus_app_name', new_callable=PropertyMock)
+class TestPelorusCommitTimestampMetric_validate_required_config_or_previous_step_result_artifact_keys(
+    TestPelorusCommitTimestampMetricBase
+):
+    def test_valid(
+        self,
+        mock_pelorus_app_name,
+        mock_super_validate_required_config_or_previous_step_result_artifact_keys
+    ):
+        # setup mocks
+        mock_pelorus_app_name.return_value = 'mock-valid-pelorus-app-name'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+        # verify
+        mock_super_validate_required_config_or_previous_step_result_artifact_keys.assert_called_once()
+        mock_pelorus_app_name.assert_called_once()
+
+    def test_invalid_pelorus_app_name(
+        self,
+        mock_pelorus_app_name,
+        mock_super_validate_required_config_or_previous_step_result_artifact_keys
+    ):
+        # setup mocks
+        mock_pelorus_app_name.return_value = 'mock-invalid-pelorus-app-name-that-is-to-long-for-kube-to-handle-kuz-kube-has-silly-limits'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Given Pelorus Application Name \(mock-invalid-pelorus-app-name-that-is-to-long-for-kube-to-handle-kuz-kube-has-silly-limits\) is invalid because it is" \
+            " longer than 63 characters which because it is expected to be a" \
+            " kubernetes label value breaks the kubernetes label value length rules." \
+            " https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set"
+        ):
+            step_implementer._validate_required_config_or_previous_step_result_artifact_keys()
+
+        # verify
+        mock_super_validate_required_config_or_previous_step_result_artifact_keys.assert_called_once()
+        mock_pelorus_app_name.assert_called()
+
+
+@patch.object(PelorusCommitTimestampMetric, 'get_value')
+class TestPelorusCommitTimestampMetric_properties(TestPelorusCommitTimestampMetricBase):
+    def test_commit_hash(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-hash'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.commit_hash
+
+        # verify
+        self.assertEqual(actual_result, 'mock-hash')
+        mock_get_value.assert_called_once_with('commit-hash')
+
+    def test_commit_utc_timestamp(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-utc-timestamp'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.commit_utc_timestamp
+
+        # verify
+        self.assertEqual(actual_result, 'mock-utc-timestamp')
+        mock_get_value.assert_called_once_with('commit-utc-timestamp')
+
+    def test_container_image_digest(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-image-digest'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.container_image_digest
+
+        # verify
+        self.assertEqual(actual_result, 'mock-image-digest')
+        mock_get_value.assert_called_once_with(
+            ['container-image-push-digest', 'container-image-digest']
+        )
+
+    def test_pelorus_prometheus_pushgateway_url(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-url'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.pelorus_prometheus_pushgateway_url
+
+        # verify
+        self.assertEqual(actual_result, 'mock-url')
+        mock_get_value.assert_called_once_with('pelorus-prometheus-pushgateway-url')
+
+    def test_pelorus_prometheus_job(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-job'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.pelorus_prometheus_job
+
+        # verify
+        self.assertEqual(actual_result, 'mock-job')
+        mock_get_value.assert_called_once_with('pelorus-prometheus-job')
+
+    def test_pelorus_app_name(self, mock_get_value):
+        # setup mocks
+        mock_get_value.return_value = 'mock-app-name'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer.pelorus_app_name
+
+        # verify
+        self.assertEqual(actual_result, 'mock-app-name')
+        mock_get_value.assert_called_once_with('pelorus-app-name')
+
+@patch('ploigos_step_runner.step_implementers.push_container_image.pelorus_commit_timestamp_metric.push_to_gateway')
+@patch.object(PelorusCommitTimestampMetric, 'pelorus_app_name', new_callable=PropertyMock)
+@patch.object(PelorusCommitTimestampMetric, 'commit_hash', new_callable=PropertyMock)
+@patch.object(PelorusCommitTimestampMetric, 'container_image_digest', new_callable=PropertyMock)
+@patch.object(PelorusCommitTimestampMetric, 'commit_utc_timestamp', new_callable=PropertyMock)
+@patch.object(PelorusCommitTimestampMetric, 'pelorus_prometheus_pushgateway_url', new_callable=PropertyMock)
+@patch.object(PelorusCommitTimestampMetric, 'pelorus_prometheus_job', new_callable=PropertyMock)
+class TestPelorusCommitTimestampMetric_run_step(
+    TestPelorusCommitTimestampMetricBase
+):
+    def test_success(
+        self,
+        mock_pelorus_prometheus_job,
+        mock_pelorus_prometheus_pushgateway_url,
+        mock_commit_utc_timestamp,
+        mock_container_image_digest,
+        mock_commit_hash,
+        mock_pelorus_app_name,
+        mock_push_to_gateway
+    ):
+        # setup mocks
+        mock_pelorus_prometheus_job.return_value = 'mock-job'
+        mock_pelorus_prometheus_pushgateway_url.return_value = 'mock-push-url'
+        mock_commit_utc_timestamp.return_value = '1642079293.0'
+        mock_container_image_digest.return_value = 'mock-digest'
+        mock_commit_hash.return_value = 'mock-commit-hash'
+        mock_pelorus_app_name.return_value = 'mock-app-name'
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer._run_step()
+
+        # verify
+        expected_step_result = StepResult(
+            step_name='push-container-image',
+            sub_step_name='PelorusCommitTimestampMetric',
+            sub_step_implementer_name='PelorusCommitTimestampMetric'
+        )
+        self.assertEqual(actual_result, expected_step_result)
+        mock_push_to_gateway.assert_called_once_with(
+            gateway='mock-push-url',
+            job='mock-job',
+            grouping_key={
+                'job': 'mock-job',
+                'app': 'mock-app-name',
+                'commit': 'mock-commit-hash'
+            },
+            registry=ANY
+        )
+
+    def test_push_error(
+        self,
+        mock_pelorus_prometheus_job,
+        mock_pelorus_prometheus_pushgateway_url,
+        mock_commit_utc_timestamp,
+        mock_container_image_digest,
+        mock_commit_hash,
+        mock_pelorus_app_name,
+        mock_push_to_gateway
+    ):
+        # setup mocks
+        mock_pelorus_prometheus_job.return_value = 'mock-job'
+        mock_pelorus_prometheus_pushgateway_url.return_value = 'mock-push-url'
+        mock_commit_utc_timestamp.return_value = '1642079293.0'
+        mock_container_image_digest.return_value = 'mock-digest'
+        mock_commit_hash.return_value = 'mock-commit-hash'
+        mock_pelorus_app_name.return_value = 'mock-app-name'
+        mock_push_to_gateway.side_effect = Exception('mock push error')
+
+        # setup
+        step_implementer = self.create_step_implementer()
+
+        # run step
+        actual_result = step_implementer._run_step()
+
+        # verify
+        expected_step_result = StepResult(
+            step_name='push-container-image',
+            sub_step_name='PelorusCommitTimestampMetric',
+            sub_step_implementer_name='PelorusCommitTimestampMetric'
+        )
+        expected_step_result.success = False
+        expected_step_result.message = "Error pushing Pelorus Commit Timestamp metric to" \
+            " Prometheus Pushgateway (mock-push-url): mock push error"
+        self.assertEqual(actual_result, expected_step_result)
+        mock_push_to_gateway.assert_called_once_with(
+            gateway='mock-push-url',
+            job='mock-job',
+            grouping_key={
+                'job': 'mock-job',
+                'app': 'mock-app-name',
+                'commit': 'mock-commit-hash'
+            },
+            registry=ANY
+        )


### PR DESCRIPTION
# Purpose

Add ability for Ploigos to push [pelorus](https://github.com/konveyor/pelorus) CommitTimestamp metric.

# Breaking?
No

# Integration Testing
Only did integration testing with minimal on jenkins because wont make a diff for other steps in more complicated pipeliens or different pipeline runners.


* [Minimal](https://jenkins-jenkins.apps.tssc.rht-set.com/job/Ploigos%20Reference%20Applciations%20(minimal)/job/reference-quarkus-mvn/view/change-requests/job/PR-61/22/)


![Screen Shot 2022-01-24 at 3 15 16 PM](https://user-images.githubusercontent.com/183245/150857703-75b7da88-18b1-461c-82b1-bede83e2c0c8.png)

