### PR TITLE
Add missing comma to default maven args in the Maven Deploy step runner

### DIFF
--- a/src/ploigos_step_runner/step_implementers/push_artifacts/maven_deploy.py
+++ b/src/ploigos_step_runner/step_implementers/push_artifacts/maven_deploy.py
@@ -19,7 +19,7 @@ Configuration Key            | Required? | Default | Description
                             `False` to have the transfer progress printed.\
                             See https://maven.apache.org/ref/current/maven-embedder/cli.html
 `maven-additional-arguments` | No        | `['-Dmaven.install.skip=true', \
-                                             '-Dmaven.test.skip=true' \
+                                             '-Dmaven.test.skip=true', \
                                              '-DskipTests', \
                                              '-DskipITs']` \
                                                    | List of additional arguments to use. \
@@ -58,7 +58,7 @@ from ploigos_step_runner.utils.maven import run_maven
 DEFAULT_CONFIG = {
     'maven-additional-arguments': [
         '-Dmaven.install.skip=true',
-        '-Dmaven.test.skip=true'
+        '-Dmaven.test.skip=true',
         '-DskipTests',
         '-DskipITs'
     ]

--- a/tests/step_implementers/push_artifacts/test_maven_deploy.py
+++ b/tests/step_implementers/push_artifacts/test_maven_deploy.py
@@ -65,7 +65,7 @@ class TestStepImplementerMavenDeploy_step_implementer_config_defaults(
                 'maven-no-transfer-progress': True,
                 'maven-additional-arguments': [
                     '-Dmaven.install.skip=true',
-                    '-Dmaven.test.skip=true'
+                    '-Dmaven.test.skip=true',
                     '-DskipTests',
                     '-DskipITs'
                 ]


### PR DESCRIPTION
# Purpose

Currently, the default value for `maven-additional-arguments` in the Maven Deploy step (under push_artifacts) is missing a comma, which causes the two values that disable testing to merge together and ultimately be ignored. This is forcing a rerun of the tests during the push_artifacts activity for Maven builds.

# Breaking?
No

# Integration Testing
**TBD**