### PR TITLE
Git Utils class

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
@@ -123,7 +123,7 @@ from ploigos_step_runner.results import StepResult
 from ploigos_step_runner.exceptions import StepRunnerException
 from ploigos_step_runner.step_implementers.shared import (ArgoCDGeneric,
                                                           ContainerDeployMixin)
-from ploigos_step_runner.utils.git import *
+from ploigos_step_runner.utils.git import clone_repo, git_config, git_checkout, git_commit_file
 
 DEFAULT_CONFIG = {
     'argocd-sync-timeout-seconds': 60,
@@ -278,7 +278,7 @@ class ArgoCDDeploy(ContainerDeployMixin, ArgoCDGeneric):
 
             # clone the configuration repository
             print("Clone the configuration repository")
-            deployment_config_repo_dir = self.create_working_dir_sub_dir('deployment-config-repo');
+            deployment_config_repo_dir = self.create_working_dir_sub_dir('deployment-config-repo')
 
             clone_repo(
                 repo_dir=deployment_config_repo_dir,

--- a/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
@@ -10,7 +10,7 @@ import sh
 import yaml
 from ploigos_step_runner.step_implementer import StepImplementer
 from ploigos_step_runner.exceptions import StepRunnerException
-from ploigos_step_runner.utils.git import (clone_repo, git_tag_and_push, get_git_repo_regex)
+from ploigos_step_runner.utils.git import (git_tag_and_push, get_git_repo_regex)
 from ploigos_step_runner.utils.io import \
     create_sh_redirect_to_multiple_streams_fn_callback
 

--- a/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
+++ b/src/ploigos_step_runner/step_implementers/shared/git_mixin.py
@@ -1,5 +1,9 @@
 """A mixin class designed to add shared functionality to StepImplementers that interact with Git.
 
+NOTE: There is heavy overlap between this class and the git utils. An architectural decision needs
+      to be made on composition vs. multiple inheritance for gaining consistency between unrelated
+      step implementers that require the same configuration parameters / behaviors.
+
 Step Configuration
 ------------------
 Step configuration expected as input to this step.

--- a/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
+++ b/src/ploigos_step_runner/step_implementers/static_code_analysis/sonarqube.py
@@ -13,7 +13,8 @@ Could come from:
 
 Key                      | Required | Default                     | Description
 -------------------------|----------|-----------------------------|------------
-`properties`             | Yes      | `./sonar-project.proerties` | Existing properties file for SonarQube
+`properties`             | Yes      | `./sonar-project.properties` \
+                                                                  | Existing properties file for SonarQube
 `url`                    | Yes      |                             | SonarQube host url (sonar.host.url)
 `username`               | No       |                             | SonarQube username id (sonar.login)
 `password`               | No       |                             | SonarQube password
@@ -21,7 +22,7 @@ Key                      | Required | Default                     | Description
 `version`                | Yes      |                             | Version to use for the SonarQube \
                                                                     project version (sonar.projectVersion)
 `java-truststore`        | No       | `/etc/pki/java/cacerts`     | Location of Java TrustStore. Defaults \
-                                                             to System.
+                                                                    to System.
 `project-key`            | No       |                             | SonarQube project key
 `sonar-analyze-branches` | No       | `False`                     | `True` to pass the `sonar.branch.name` property to SonarQube, \
                                                                     which can only be done if using SonarQube Developer Edition or above as per \

--- a/src/ploigos_step_runner/utils/git.py
+++ b/src/ploigos_step_runner/utils/git.py
@@ -1,0 +1,244 @@
+"""Shared utils for git operations.
+"""
+
+import re
+import sys
+import sh
+from ploigos_step_runner.exceptions import StepRunnerException
+
+GIT_REPO_REGEX = re.compile(r"(?P<protocol>^https:\/\/|^http:\/\/)?(?P<address>.*$)")
+
+def clone_repo(  # pylint: disable=too-many-arguments
+    repo_dir,
+    repo_url,
+    username=None,
+    password=None
+):
+    """Clones and checks out the deployment configuration repository.
+
+    Parameters
+    ----------
+    repo_dir : str
+        Path to where to clone the repository
+    repo_uri : str
+        URI of the repository to clone.
+
+    Returns
+    -------
+    str
+        Path to the directory where the deployment configuration repository was cloned
+        and checked out.
+
+    Raises
+    ------
+    StepRunnerException
+    * if error cloning repository
+    * if error checking out branch of repository
+    * if error configuring repo user
+    """
+    repo_match = get_git_repo_regex().match(repo_url)
+    repo_protocol = repo_match.groupdict()['protocol']
+    repo_address = repo_match.groupdict()['address']
+
+    # if deployment config repo uses http/https push using user/pass
+    # else push using ssh
+    if username and password and repo_protocol and re.match(
+            r'^http://|^https://',
+            repo_protocol
+    ):
+        repo_url_with_auth = \
+            f"{repo_protocol}{username}:{password}" \
+            f"@{repo_address}"
+    else:
+        repo_url_with_auth = repo_url
+
+    try:
+        sh.git.clone(  # pylint: disable=no-member
+            repo_url_with_auth,
+            repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+    except sh.ErrorReturnCode as error:
+        raise StepRunnerException(
+            f"Error cloning repository ({repo_url}): {error}"
+        ) from error
+
+def git_config(  # pylint: disable=too-many-arguments
+    repo_dir,
+    git_email,
+    git_name
+):
+    """Sets the git config (username + email) for the git repository residing under repo_dir.
+
+    Parameters
+    ----------
+    repo_dir : str
+        Path to where to clone the repository
+    git_email : str
+        email to use when performing git operations in the cloned repository
+    git_name : str
+        name to use when performing git operations in the cloned repository
+
+    Raises
+    ------
+    StepRunnerException
+    * if error configuring repo user
+    """
+
+    try:
+        sh.git.config(  # pylint: disable=no-member
+            'user.email',
+            git_email,
+            _cwd=repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+        sh.git.config(  # pylint: disable=no-member
+            'user.name',
+            git_name,
+            _cwd=repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+    except sh.ErrorReturnCode as error:
+        # NOTE: this should never happen
+        raise StepRunnerException(
+            f"Unexpected error configuring git user.email ({git_email})"
+            f" and user.name ({git_name}) for repository"
+            f" under directory ({repo_dir}): {error}"
+        ) from error
+
+def git_checkout(
+    repo_dir,
+    repo_branch
+):
+    try:
+        # no atomic way in git to checkout out new or existing branch,
+        # so first try to check out existing, if that doesn't work try new
+        try:
+            sh.git.checkout(  # pylint: disable=no-member
+                repo_branch,
+                _cwd=repo_dir,
+                _out=sys.stdout,
+                _err=sys.stderr
+            )
+        except sh.ErrorReturnCode:
+            sh.git.checkout(
+                '-b',
+                repo_branch,
+                _cwd=repo_dir,
+                _out=sys.stdout,
+                _err=sys.stderr
+            )
+    except sh.ErrorReturnCode as error:
+        # NOTE: this should never happen
+        raise StepRunnerException(
+            f"Unexpected error checking out new or existing branch ({repo_branch})"
+            f" from repository under directory ({repo_dir}): {error}"
+        ) from error
+
+def git_commit_file(
+    git_commit_message,
+    file_path,
+    repo_dir
+):
+    try:
+        sh.git.add( # pylint: disable=no-member
+            file_path,
+            _cwd=repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+    except sh.ErrorReturnCode as error:
+        # NOTE: this should never happen
+        raise StepRunnerException(
+            f"Unexpected error adding file ({file_path}) to commit"
+            f" in git repository ({repo_dir}): {error}"
+        ) from error
+
+    try:
+        sh.git.commit( # pylint: disable=no-member
+            '--allow-empty',
+            '--all',
+            '--message', git_commit_message,
+            _cwd=repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+    except sh.ErrorReturnCode as error:
+        # NOTE: this should never happen
+        raise StepRunnerException(
+            f"Unexpected error commiting file ({file_path})"
+            f" in git repository ({repo_dir}): {error}"
+        ) from error
+
+def git_tag_and_push(
+    repo_dir,
+    tag,
+    url=None,
+    force_push_tags=False
+):
+    """
+    Raises
+    ------
+    StepRunnerException
+    * if error pushing commits
+    * if error tagging repository
+    * if error pushing tags
+    """
+
+    git_push = sh.git.push.bake(url) if url else sh.git.push
+
+    # push commits
+    try:
+        git_push(
+            _cwd=repo_dir,
+            _out=sys.stdout
+        )
+    except sh.ErrorReturnCode as error:
+        raise StepRunnerException(
+            f"Error pushing commits from repository directory ({repo_dir}) to"
+            f" repository ({url}): {error}"
+        ) from error
+
+    # tag
+    try:
+        # NOTE:
+        # this force is only needed locally in case of a re-run of the same pipeline
+        # without a fresh check out. You will notice there is no force on the push
+        # making this an acceptable work around to the issue since on the off chance
+        # actually overwriting a tag with a different comment, the push will fail
+        # because the tag will be attached to a different git hash.
+        sh.git.tag(  # pylint: disable=no-member
+            tag,
+            '-f',
+            _cwd=repo_dir,
+            _out=sys.stdout,
+            _err=sys.stderr
+        )
+    except sh.ErrorReturnCode as error:
+        raise StepRunnerException(
+            f"Error tagging repository ({repo_dir}) with tag ({tag}): {error}"
+        ) from error
+
+    git_push_additional_arguments = []
+    if force_push_tags:
+        git_push_additional_arguments += ["--force"]
+
+    # push tag
+    try:
+        git_push(
+            '--tag',
+            *git_push_additional_arguments,
+            _cwd=repo_dir,
+            _out=sys.stdout
+        )
+    except sh.ErrorReturnCode as error:
+        raise StepRunnerException(
+            f"Error pushing tags from repository directory ({repo_dir}) to"
+            f" repository ({url}): {error}"
+        ) from error
+
+def get_git_repo_regex():
+    return GIT_REPO_REGEX

--- a/tests/step_implementers/shared/test_argocd_generic.py
+++ b/tests/step_implementers/shared/test_argocd_generic.py
@@ -1,9 +1,9 @@
 import os
 import re
-from io import IOBase
 from unittest.mock import ANY, call, patch
 
 import sh
+
 from ploigos_step_runner.exceptions import StepRunnerException
 from ploigos_step_runner.step_implementers.shared.argocd_generic import \
     ArgoCDGeneric
@@ -29,6 +29,7 @@ class MockArgoCDGenericImpl(ArgoCDGeneric):
     def _run_step(self):
         pass
 
+
 class TestStepImplementerSharedArgoCDBase(BaseStepImplementerTestCase):
     def create_step_implementer(
         self,
@@ -44,6 +45,7 @@ class TestStepImplementerSharedArgoCDBase(BaseStepImplementerTestCase):
             parent_work_dir_path=parent_work_dir_path,
             environment=environment
         )
+
 
 class TestStepImplementerSharedArgoCDGenericget_deployment_config_helm_chart_environment_values_file(
     TestStepImplementerSharedArgoCDBase
@@ -100,6 +102,7 @@ class TestStepImplementerSharedArgoCDGenericget_deployment_config_helm_chart_env
                 deployment_config_helm_chart_env_value_file,
                 'values-PROD.yaml'
             )
+
 
 class TestStepImplementerSharedArgoCDGenericupdate_yaml_file_value(TestStepImplementerSharedArgoCDBase):
     @patch('sh.yq', create=True)
@@ -195,8 +198,9 @@ class TestStepImplementerSharedArgoCDGenericupdate_yaml_file_value(TestStepImple
                         f"    v0.42.0-abc123 # written by ploigos-step-runner\n",
                     )
 
+
 class TestStepImplementerSharedArgoCDGenericgit_tag_and_push_deployment_config_repo(TestStepImplementerSharedArgoCDBase):
-    @patch.object(ArgoCDGeneric, '_git_tag_and_push')
+    @patch('ploigos_step_runner.step_implementers.shared.argocd_generic.git_tag_and_push')
     def test_git_tag_and_push_deployment_config_repo_http(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
@@ -222,7 +226,7 @@ class TestStepImplementerSharedArgoCDGenericgit_tag_and_push_deployment_config_r
                 force_push_tags=False
             )
 
-    @patch.object(ArgoCDGeneric, '_git_tag_and_push')
+    @patch('ploigos_step_runner.step_implementers.shared.argocd_generic.git_tag_and_push')
     def test_git_tag_and_push_deployment_config_repo_https(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
@@ -248,7 +252,7 @@ class TestStepImplementerSharedArgoCDGenericgit_tag_and_push_deployment_config_r
                 force_push_tags=False
             )
 
-    @patch.object(ArgoCDGeneric, '_git_tag_and_push')
+    @patch('ploigos_step_runner.step_implementers.shared.argocd_generic.git_tag_and_push')
     def test_git_tag_and_push_deployment_config_repo_ssh(self, git_tag_and_push_mock):
         with TempDirectory() as temp_dir:
             parent_work_dir_path = os.path.join(temp_dir.path, 'working')
@@ -378,6 +382,7 @@ class TestStepImplementerSharedArgoCDGenericget_app_name(TestStepImplementerShar
             app_name = step_implementer._get_app_name()
             self.assertEqual(app_name, 'test-org-test-app-test-service-feature-v0-1-2')
 
+
 class TestStepImplementerSharedArgoCDGenericget_deployment_config_repo_tag(TestStepImplementerSharedArgoCDBase):
     def test_get_deployment_config_repo_tag_use_tag(self):
         with TempDirectory() as temp_dir:
@@ -437,6 +442,7 @@ class TestStepImplementerSharedArgoCDGenericget_deployment_config_repo_tag(TestS
 
             deployment_config_repo_tag = step_implementer._get_deployment_config_repo_tag()
             self.assertEqual(deployment_config_repo_tag, 'v0.42.0-main+abc123.PROD')
+
 
 class TestStepImplementerSharedArgoCDGenericget_deployed_host_urls(TestStepImplementerSharedArgoCDBase):
     def __run__get_deployed_host_urls_test(
@@ -906,418 +912,6 @@ status:
             ]
         )
 
-class TestStepImplementerSharedArgoCDGenericclone_repo(TestStepImplementerSharedArgoCDBase):
-    @patch.object(sh, 'git')
-    def test_clone_repo_success_new_branch(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'Password'
-        ArgoCDGeneric._clone_repo(
-            repo_dir=repo_dir,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            git_email=git_email,
-            git_name=git_name,
-            username=username,
-            password=password
-        )
-
-        git_mock.clone.assert_called_once_with(
-            repo_url,
-            repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-        git_mock.checkout.assert_called_once_with(
-            repo_branch,
-            _cwd=repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-        git_mock.config.assert_has_calls([
-            call(
-                'user.email',
-                git_email,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            ),
-            call(
-                'user.name',
-                git_name,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-        ])
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_success_new_branch_https(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'https://Test:Password@git.ploigos.xyz'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'Password'
-        repo_url_with_auth = 'https://git.ploigos.xyz'
-        ArgoCDGeneric._clone_repo(
-            repo_dir=repo_dir,
-            repo_url=repo_url_with_auth,
-            repo_branch=repo_branch,
-            git_email=git_email,
-            git_name=git_name,
-            username=username,
-            password=password
-        )
-
-        git_mock.clone.assert_called_once_with(
-            repo_url,
-            repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-        git_mock.checkout.assert_called_once_with(
-            repo_branch,
-            _cwd=repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-        git_mock.config.assert_has_calls([
-            call(
-                'user.email',
-                git_email,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            ),
-            call(
-                'user.name',
-                git_name,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-        ])
-
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_success_existing_branch(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'password'
-
-        git_mock.checkout.side_effect = [
-            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout branch does not exist'),
-            None
-        ]
-
-        ArgoCDGeneric._clone_repo(
-            repo_dir=repo_dir,
-            repo_url=repo_url,
-            repo_branch=repo_branch,
-            git_email=git_email,
-            git_name=git_name,
-            username=username,
-            password=password
-        )
-
-        git_mock.clone.assert_called_once_with(
-            repo_url,
-            repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-        git_mock.checkout.assert_has_calls([
-            call(
-                repo_branch,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            ),
-            call(
-                '-b',
-                repo_branch,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-        ])
-        git_mock.config.assert_has_calls([
-            call(
-                'user.email',
-                git_email,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            ),
-            call(
-                'user.name',
-                git_name,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-        ])
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_fail_clone(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'password'
-
-        git_mock.clone.side_effect = create_sh_side_effect(
-            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git clone error')
-        )
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Error cloning repository \({repo_url}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git clone error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._clone_repo(
-                repo_dir=repo_dir,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                git_email=git_email,
-                git_name=git_name,
-                username=username,
-                password=password
-            )
-
-            git_mock.clone.assert_called_once_with(
-                repo_url,
-                repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-            git_mock.checkout.assert_not_called()
-            git_mock.config.assert_not_called()
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_fail_existing_branch(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'password'
-
-        git_mock.checkout.side_effect = [
-            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout branch does not exist'),
-            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout new branch error'),
-        ]
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Unexpected error checking out new or existing branch \({repo_branch}\)"
-                rf" from repository \({repo_url}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git checkout new branch error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._clone_repo(
-                repo_dir=repo_dir,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                git_email=git_email,
-                git_name=git_name,
-                username=username,
-                password=password
-            )
-
-            git_mock.clone.assert_called_once_with(
-                repo_url,
-                repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-            git_mock.checkout.assert_has_calls([
-                call(
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                ),
-                call(
-                    '-b',
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                )
-            ])
-            git_mock.config.assert_not_called()
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_fail_config_email(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'password'
-
-        git_mock.config.side_effect = [
-            sh.ErrorReturnCode('git', b'mock out', b'mock git config email error'),
-            None
-        ]
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Unexpected error configuring git user.email \({git_email}\)"
-                rf" and user.name \({git_name}\) for repository \({repo_url}\)"
-                rf" in directory \({repo_dir}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git config email error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._clone_repo(
-                repo_dir=repo_dir,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                git_email=git_email,
-                git_name=git_name,
-                username=username,
-                password=password
-            )
-
-            git_mock.clone.assert_called_once_with(
-                repo_url,
-                repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-            git_mock.checkout.assert_has_calls([
-                call(
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                ),
-                call(
-                    '-b',
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                )
-            ])
-            git_mock.config.assert_called_once_with(
-                'user.email',
-                git_email,
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-
-    @patch.object(sh, 'git')
-    def test_clone_repo_fail_config_name(self, git_mock):
-        repo_dir = '/does/not/matter'
-        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
-        repo_branch = 'feature/test'
-        git_email = 'test@ploigos.xyz'
-        git_name = 'Test Robot'
-        username = 'Test'
-        password = 'password'
-
-        git_mock.config.side_effect = [
-            None,
-            sh.ErrorReturnCode('git', b'mock out', b'mock git config name error')
-        ]
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Unexpected error configuring git user.email \({git_email}\)"
-                rf" and user.name \({git_name}\) for repository \({repo_url}\)"
-                rf" in directory \({repo_dir}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git config name error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._clone_repo(
-                repo_dir=repo_dir,
-                repo_url=repo_url,
-                repo_branch=repo_branch,
-                git_email=git_email,
-                git_name=git_name,
-                username=username,
-                password=password
-            )
-
-            git_mock.clone.assert_called_once_with(
-                repo_url,
-                repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-            git_mock.checkout.assert_has_calls([
-                call(
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                ),
-                call(
-                    '-b',
-                    repo_branch,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                )
-            ])
-            git_mock.config.assert_has_calls([
-                call(
-                    'user.email',
-                    git_email,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                ),
-                call(
-                    'user.name',
-                    git_name,
-                    _cwd=repo_dir,
-                    _out=ANY,
-                    _err=ANY
-                )
-            ])
 
 class TestStepImplementerSharedArgoCDGenericget_repo_branch(TestStepImplementerSharedArgoCDBase):
     def test_get_repo_branch_success(self):
@@ -1341,327 +935,6 @@ class TestStepImplementerSharedArgoCDGenericget_repo_branch(TestStepImplementerS
             # validate
             self.assertEqual(repo_branch, 'feature/test')
 
-class TestStepImplementerSharedArgoCDGenericgit_tag_and_push(TestStepImplementerSharedArgoCDBase):
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_success_ssh(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = None
-        ArgoCDGeneric._git_tag_and_push(
-            repo_dir=repo_dir,
-            tag=tag,
-            url=url
-        )
-
-        git_mock.push.assert_has_calls([
-            call(
-                _cwd=repo_dir,
-                _out=ANY
-            ),
-            call(
-                '--tag',
-                _cwd=repo_dir,
-                _out=ANY
-            )
-        ])
-        git_mock.tag.assert_called_once_with(
-            tag,
-            '-f',
-            _cwd=repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_success_https_url(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = 'https://user:pass@git.ploigos.xyz'
-        ArgoCDGeneric._git_tag_and_push(
-            repo_dir=repo_dir,
-            tag=tag,
-            url=url
-        )
-
-        git_mock.push.bake().assert_has_calls([
-            call(
-                _cwd=repo_dir,
-                _out=ANY
-            ),
-            call(
-                '--tag',
-                _cwd=repo_dir,
-                _out=ANY
-            )
-        ])
-        git_mock.tag.assert_called_once_with(
-            tag,
-            '-f',
-            _cwd=repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_fail_commit(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = None
-
-        git_mock.push.side_effect = [
-            sh.ErrorReturnCode('git', b'mock out', b'mock git push error'),
-            create_sh_side_effect()
-        ]
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Error pushing commits from repository directory \({repo_dir}\) to"
-                rf" repository \({url}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git push error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._git_tag_and_push(
-                repo_dir=repo_dir,
-                tag=tag,
-                url=url
-            )
-
-            git_mock.push.assert_has_calls([
-                call(
-                    _cwd=repo_dir,
-                    _out=ANY
-                )
-            ])
-
-            git_mock.tag.assert_not_called()
-
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_fail_tag(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = None
-
-        git_mock.tag.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock git tag error')
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Error tagging repository \({repo_dir}\) with tag \({tag}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git tag error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._git_tag_and_push(
-                repo_dir=repo_dir,
-                tag=tag,
-                url=url
-            )
-
-            git_mock.push.assert_called_once_with(
-                _cwd=repo_dir,
-                _out=ANY
-            )
-
-            git_mock.tag.assert_called_once_with(
-                tag,
-                '-f',
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_fail_push_tag(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = None
-
-        git_mock.push.side_effect = [
-            create_sh_side_effect(),
-            sh.ErrorReturnCode('git', b'mock out', b'mock git push tag error')
-        ]
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                rf"Error pushing tags from repository directory \({repo_dir}\) to"
-                rf" repository \({url}\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git push tag error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._git_tag_and_push(
-                repo_dir=repo_dir,
-                tag=tag,
-                url=url
-            )
-
-            git_mock.push.bake().assert_has_calls([
-                call(
-                    _cwd=repo_dir,
-                    _out=ANY
-                ),
-                call(
-                    '--tag',
-                    _cwd=repo_dir,
-                    _out=ANY
-                )
-            ])
-
-            git_mock.tag.assert_called_once_with(
-                tag,
-                '-f',
-                _cwd=repo_dir,
-                _out=ANY,
-                _err=ANY
-            )
-
-    @patch.object(sh, 'git')
-    def test_git_tag_and_push_override_tls(self, git_mock):
-        repo_dir = '/does/not/matter'
-        tag = 'v0.42.0'
-        url = None
-        ArgoCDGeneric._git_tag_and_push(
-            repo_dir=repo_dir,
-            tag=tag,
-            url=url,
-            force_push_tags=True
-        )
-
-        git_mock.push.assert_has_calls([
-            call(
-                _cwd=repo_dir,
-                _out=ANY
-            ),
-            call(
-                '--tag',
-                '--force',
-                _cwd=repo_dir,
-                _out=ANY
-            )
-        ])
-        git_mock.tag.assert_called_once_with(
-            tag,
-            '-f',
-            _cwd=repo_dir,
-            _out=ANY,
-            _err=ANY
-        )
-
-
-class TestStepImplementerSharedArgoCDGenericgit_commit_file(TestStepImplementerSharedArgoCDBase):
-    @patch.object(sh, 'git')
-    def test_git_commit_file_success(self, git_mock):
-        ArgoCDGeneric._git_commit_file(
-            git_commit_message='hello world',
-            file_path='charts/foo/values-DEV.yaml',
-            repo_dir='/does/not/matter'
-        )
-
-        git_mock.add.assert_called_once_with(
-            'charts/foo/values-DEV.yaml',
-            _cwd='/does/not/matter',
-            _out=ANY,
-            _err=ANY
-        )
-
-        git_mock.commit.assert_called_once_with(
-            '--allow-empty',
-            '--all',
-            '--message', 'hello world',
-            _cwd='/does/not/matter',
-            _out=ANY,
-            _err=ANY
-        )
-
-    @patch.object(sh, 'git')
-    def test_git_commit_file_fail_add(self, git_mock):
-        git_mock.add.side_effect = create_sh_side_effect(
-            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git add error')
-        )
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                r"Unexpected error adding file \(charts/foo/values-DEV.yaml\) to commit"
-                r" in git repository \(/does/not/matter\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git add error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._git_commit_file(
-                git_commit_message='hello world',
-                file_path='charts/foo/values-DEV.yaml',
-                repo_dir='/does/not/matter'
-            )
-
-            git_mock.add.assert_called_once_with(
-                'charts/foo/values-DEV.yaml',
-                _cwd='/does/not/matter',
-                _out=ANY,
-                _err=ANY
-            )
-
-            git_mock.commit.assert_not_called()
-
-    @patch.object(sh, 'git')
-    def test_git_commit_file_fail_commit(self, git_mock):
-        git_mock.commit.side_effect = create_sh_side_effect(
-            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git commit error')
-        )
-
-        with self.assertRaisesRegex(
-            StepRunnerException,
-            re.compile(
-                r"Unexpected error commiting file \(charts/foo/values-DEV.yaml\)"
-                r" in git repository \(/does/not/matter\):"
-                r".*RAN: git"
-                r".*STDOUT:"
-                r".*mock out"
-                r".*STDERR:"
-                r".*mock git commit error",
-                re.DOTALL
-            )
-        ):
-            ArgoCDGeneric._git_commit_file(
-                git_commit_message='hello world',
-                file_path='charts/foo/values-DEV.yaml',
-                repo_dir='/does/not/matter'
-            )
-
-            git_mock.add.assert_called_once_with(
-                'charts/foo/values-DEV.yaml',
-                _cwd='/does/not/matter',
-                _out=ANY,
-                _err=ANY
-            )
-
-            git_mock.commit.assert_called_once_with(
-                '--allow-empty',
-                '--all',
-                '--message', 'hello world',
-                _cwd='/does/not/matter',
-                _out=ANY,
-                _err=ANY
-            )
 
 class TestStepImplementerSharedArgoCDGenericArgoCD_sign_in(TestStepImplementerSharedArgoCDBase):
     @patch('sh.argocd', create=True)
@@ -1743,6 +1016,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_sign_in(TestStepImplementerSh
                 _out=ANY,
                 _err=ANY
             )
+
 
 class TestStepImplementerSharedArgoCDGenericArgoCD_add_target_cluster(TestStepImplementerSharedArgoCDBase):
     @patch('sh.argocd', create=True)
@@ -2166,6 +1440,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             _out=ANY,
             _err=ANY
         )
+
 
 @patch.object(ArgoCDGeneric, '_argocd_app_wait_for_health')
 @patch.object(ArgoCDGeneric, '_argocd_app_wait_for_operation')

--- a/tests/utils/test_git.py
+++ b/tests/utils/test_git.py
@@ -1,0 +1,629 @@
+"""Test for git.py
+
+Test for the utility for git operations.
+"""
+
+from unittest.mock import ANY, call, patch
+
+from ploigos_step_runner.utils.git import *
+from tests.helpers.base_test_case import BaseTestCase
+from tests.helpers.test_utils import create_sh_side_effect
+
+
+class TestGitUtils_get_git_repo_regex(BaseTestCase):
+    def test_get_git_repo_regex(self):
+        self.assertEqual(
+            re.compile(r'(?P<protocol>^https:\/\/|^http:\/\/)?(?P<address>.*$)'),
+            get_git_repo_regex()
+        )
+
+
+class TestGitUtils_clone_repo(BaseTestCase):
+    @patch('sh.git', create=True)
+    def test_clone_repo_success(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
+        username = 'Test'
+        password = 'Password'
+
+        clone_repo(
+            repo_dir=repo_dir,
+            repo_url=repo_url,
+            username=username,
+            password=password
+        )
+
+        git_mock.clone.assert_called_once_with(
+            repo_url,
+            repo_dir,
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_clone_repo_success_https(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_url = 'https://Test:Password@git.ploigos.xyz'
+        username = 'Test'
+        password = 'Password'
+        repo_url_with_auth = 'https://git.ploigos.xyz'
+
+        clone_repo(
+            repo_dir=repo_dir,
+            repo_url=repo_url_with_auth,
+            username=username,
+            password=password
+        )
+
+        git_mock.clone.assert_called_once_with(
+            repo_url,
+            repo_dir,
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_clone_repo_fail_clone(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_url = 'git@git.ploigos.xyz:/foo/test.git'
+        username = 'Test'
+        password = 'password'
+
+        git_mock.clone.side_effect = create_sh_side_effect(
+            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git clone error')
+        )
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Error cloning repository \({repo_url}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git clone error",
+                re.DOTALL
+            )
+        ):
+            clone_repo(
+                repo_dir=repo_dir,
+                repo_url=repo_url,
+                username=username,
+                password=password
+            )
+
+            git_mock.clone.assert_called_once_with(
+                repo_url,
+                repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+
+
+class TestGitUtils_git_config(BaseTestCase):
+    @patch('sh.git', create=True)
+    def test_git_config_success_new_branch(self, git_mock):
+        repo_dir = '/does/not/matter'
+        git_email = 'test@ploigos.xyz'
+        git_name = 'Test Robot'
+
+        git_config(
+            repo_dir=repo_dir,
+            git_email=git_email,
+            git_name=git_name
+        )
+
+        git_mock.config.assert_has_calls([
+            call(
+                'user.email',
+                git_email,
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            ),
+            call(
+                'user.name',
+                git_name,
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+        ])
+
+    @patch('sh.git', create=True)
+    def test_git_config_fail_config_email(self, git_mock):
+        repo_dir = '/does/not/matter'
+        git_email = 'test@ploigos.xyz'
+        git_name = 'Test Robot'
+
+        git_mock.config.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock git config email error')
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Unexpected error configuring git user.email \({git_email}\)"
+                rf" and user.name \({git_name}\) for repository"
+                rf" under directory \({repo_dir}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git config email error",
+                re.DOTALL
+            )
+        ):
+            git_config(
+                repo_dir=repo_dir,
+                git_email=git_email,
+                git_name=git_name
+            )
+
+            git_mock.config.assert_called_once_with(
+                'user.email',
+                git_email,
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+
+    @patch('sh.git', create=True)
+    def test_git_config_fail_config_name(self, git_mock):
+        repo_dir = '/does/not/matter'
+        git_email = 'test@ploigos.xyz'
+        git_name = 'Test Robot'
+
+        git_mock.config.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock git config name error')
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Unexpected error configuring git user.email \({git_email}\)"
+                rf" and user.name \({git_name}\) for repository"
+                rf" under directory \({repo_dir}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git config name error",
+                re.DOTALL
+            )
+        ):
+            git_config(
+                repo_dir=repo_dir,
+                git_email=git_email,
+                git_name=git_name
+            )
+
+            git_mock.config.assert_has_calls([
+                call(
+                    'user.email',
+                    git_email,
+                    _cwd=repo_dir,
+                    _out=ANY,
+                    _err=ANY
+                ),
+                call(
+                    'user.name',
+                    git_name,
+                    _cwd=repo_dir,
+                    _out=ANY,
+                    _err=ANY
+                )
+            ])
+
+
+class TestGitUtils_git_checkout(BaseTestCase):
+    @patch('sh.git', create=True)
+    def test_git_checkout_success_new_branch(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_branch = 'feature/test'
+
+        git_checkout(
+            repo_dir=repo_dir,
+            repo_branch=repo_branch
+        )
+
+        git_mock.checkout.assert_called_once_with(
+            repo_branch,
+            _cwd=repo_dir,
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_git_checkout_success_existing_branch(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_branch = 'feature/test'
+
+        git_mock.checkout.side_effect = [
+            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout branch does not exist'),
+            None
+        ]
+
+        git_checkout(
+            repo_dir=repo_dir,
+            repo_branch=repo_branch
+        )
+
+        git_mock.checkout.assert_has_calls([
+            call(
+                repo_branch,
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            ),
+            call(
+                '-b',
+                repo_branch,
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+        ])
+
+    @patch('sh.git', create=True)
+    def test_git_checkout_fail_existing_branch(self, git_mock):
+        repo_dir = '/does/not/matter'
+        repo_branch = 'feature/test'
+
+        git_mock.checkout.side_effect = [
+            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout branch does not exist'),
+            sh.ErrorReturnCode('git', b'mock out', b'mock git checkout new branch error'),
+        ]
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Unexpected error checking out new or existing branch \({repo_branch}\)"
+                rf" from repository under directory \({repo_dir}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git checkout new branch error",
+                re.DOTALL
+            )
+        ):
+            git_checkout(
+                repo_dir=repo_dir,
+                repo_branch=repo_branch
+            )
+
+            git_mock.checkout.assert_has_calls([
+                call(
+                    repo_branch,
+                    _cwd=repo_dir,
+                    _out=ANY,
+                    _err=ANY
+                ),
+                call(
+                    '-b',
+                    repo_branch,
+                    _cwd=repo_dir,
+                    _out=ANY,
+                    _err=ANY
+                )
+            ])
+
+
+class TestGitUtils_git_commit_file(BaseTestCase):
+    @patch('sh.git', create=True)
+    def test_git_commit_file_success(self, git_mock):
+        git_commit_file(
+            git_commit_message='hello world',
+            file_path='charts/foo/values-DEV.yaml',
+            repo_dir='/does/not/matter'
+        )
+
+        git_mock.add.assert_called_once_with(
+            'charts/foo/values-DEV.yaml',
+            _cwd='/does/not/matter',
+            _out=ANY,
+            _err=ANY
+        )
+
+        git_mock.commit.assert_called_once_with(
+            '--allow-empty',
+            '--all',
+            '--message', 'hello world',
+            _cwd='/does/not/matter',
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_git_commit_file_fail_add(self, git_mock):
+        git_mock.add.side_effect = create_sh_side_effect(
+            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git add error')
+        )
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                r"Unexpected error adding file \(charts/foo/values-DEV.yaml\) to commit"
+                r" in git repository \(/does/not/matter\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git add error",
+                re.DOTALL
+            )
+        ):
+            git_commit_file(
+                git_commit_message='hello world',
+                file_path='charts/foo/values-DEV.yaml',
+                repo_dir='/does/not/matter'
+            )
+
+            git_mock.add.assert_called_once_with(
+                'charts/foo/values-DEV.yaml',
+                _cwd='/does/not/matter',
+                _out=ANY,
+                _err=ANY
+            )
+
+            git_mock.commit.assert_not_called()
+
+    @patch('sh.git', create=True)
+    def test_git_commit_file_fail_commit(self, git_mock):
+        git_mock.commit.side_effect = create_sh_side_effect(
+            exception=sh.ErrorReturnCode('git', b'mock out', b'mock git commit error')
+        )
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                r"Unexpected error commiting file \(charts/foo/values-DEV.yaml\)"
+                r" in git repository \(/does/not/matter\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git commit error",
+                re.DOTALL
+            )
+        ):
+            git_commit_file(
+                git_commit_message='hello world',
+                file_path='charts/foo/values-DEV.yaml',
+                repo_dir='/does/not/matter'
+            )
+
+            git_mock.add.assert_called_once_with(
+                'charts/foo/values-DEV.yaml',
+                _cwd='/does/not/matter',
+                _out=ANY,
+                _err=ANY
+            )
+
+            git_mock.commit.assert_called_once_with(
+                '--allow-empty',
+                '--all',
+                '--message', 'hello world',
+                _cwd='/does/not/matter',
+                _out=ANY,
+                _err=ANY
+            )
+
+
+class TestGitUtils_git_tag_and_push(BaseTestCase):
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_success_ssh(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = None
+        git_tag_and_push(
+            repo_dir=repo_dir,
+            tag=tag,
+            url=url
+        )
+
+        git_mock.push.assert_has_calls([
+            call(
+                _cwd=repo_dir,
+                _out=ANY
+            ),
+            call(
+                '--tag',
+                _cwd=repo_dir,
+                _out=ANY
+            )
+        ])
+        git_mock.tag.assert_called_once_with(
+            tag,
+            '-f',
+            _cwd=repo_dir,
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_success_https_url(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = 'https://user:pass@git.ploigos.xyz'
+        git_tag_and_push(
+            repo_dir=repo_dir,
+            tag=tag,
+            url=url
+        )
+
+        git_mock.push.bake().assert_has_calls([
+            call(
+                _cwd=repo_dir,
+                _out=ANY
+            ),
+            call(
+                '--tag',
+                _cwd=repo_dir,
+                _out=ANY
+            )
+        ])
+        git_mock.tag.assert_called_once_with(
+            tag,
+            '-f',
+            _cwd=repo_dir,
+            _out=ANY,
+            _err=ANY
+        )
+
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_fail_commit(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = None
+
+        git_mock.push.side_effect = [
+            sh.ErrorReturnCode('git', b'mock out', b'mock git push error'),
+            create_sh_side_effect()
+        ]
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Error pushing commits from repository directory \({repo_dir}\) to"
+                rf" repository \({url}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git push error",
+                re.DOTALL
+            )
+        ):
+            git_tag_and_push(
+                repo_dir=repo_dir,
+                tag=tag,
+                url=url
+            )
+
+            git_mock.push.assert_has_calls([
+                call(
+                    _cwd=repo_dir,
+                    _out=ANY
+                )
+            ])
+
+            git_mock.tag.assert_not_called()
+
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_fail_tag(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = None
+
+        git_mock.tag.side_effect = sh.ErrorReturnCode('git', b'mock out', b'mock git tag error')
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Error tagging repository \({repo_dir}\) with tag \({tag}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git tag error",
+                re.DOTALL
+            )
+        ):
+            git_tag_and_push(
+                repo_dir=repo_dir,
+                tag=tag,
+                url=url
+            )
+
+            git_mock.push.assert_called_once_with(
+                _cwd=repo_dir,
+                _out=ANY
+            )
+
+            git_mock.tag.assert_called_once_with(
+                tag,
+                '-f',
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_fail_push_tag(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = None
+
+        git_mock.push.side_effect = [
+            create_sh_side_effect(),
+            sh.ErrorReturnCode('git', b'mock out', b'mock git push tag error')
+        ]
+
+        with self.assertRaisesRegex(
+            StepRunnerException,
+            re.compile(
+                rf"Error pushing tags from repository directory \({repo_dir}\) to"
+                rf" repository \({url}\):"
+                r".*RAN: git"
+                r".*STDOUT:"
+                r".*mock out"
+                r".*STDERR:"
+                r".*mock git push tag error",
+                re.DOTALL
+            )
+        ):
+            git_tag_and_push(
+                repo_dir=repo_dir,
+                tag=tag,
+                url=url
+            )
+
+            git_mock.push.bake().assert_has_calls([
+                call(
+                    _cwd=repo_dir,
+                    _out=ANY
+                ),
+                call(
+                    '--tag',
+                    _cwd=repo_dir,
+                    _out=ANY
+                )
+            ])
+
+            git_mock.tag.assert_called_once_with(
+                tag,
+                '-f',
+                _cwd=repo_dir,
+                _out=ANY,
+                _err=ANY
+            )
+
+    @patch('sh.git', create=True)
+    def test_git_tag_and_push_override_tls(self, git_mock):
+        repo_dir = '/does/not/matter'
+        tag = 'v0.42.0'
+        url = None
+        git_tag_and_push(
+            repo_dir=repo_dir,
+            tag=tag,
+            url=url,
+            force_push_tags=True
+        )
+
+        git_mock.push.assert_has_calls([
+            call(
+                _cwd=repo_dir,
+                _out=ANY
+            ),
+            call(
+                '--tag',
+                '--force',
+                _cwd=repo_dir,
+                _out=ANY
+            )
+        ])
+        git_mock.tag.assert_called_once_with(
+            tag,
+            '-f',
+            _cwd=repo_dir,
+            _out=ANY,
+            _err=ANY
+        )


### PR DESCRIPTION
# Purpose

This pull request breaks out the git functionality from the ArgoCD Generic/Deploy classes into a separate utility class, so that this logic can be used across other step implementers going forward.

# Breaking?
No

# Integration Testing

Run against `reference-quarkus-mvn` app.

<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
