### PR TITLE
Feature/multi uat

### DIFF
--- a/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
+++ b/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
@@ -134,17 +134,17 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
             target_substring = self.get_value('target-url-substring')
             if len(deployed_host_urls) > 1:
                 if target_substring:
-                    found_host_url = False
+                    found_target_url = False
                     for deployed_host_url in deployed_host_urls:
                         if deployed_host_url.find(target_substring) != -1:
                             target_host_url = deployed_host_url
-                            found_host_url = True
+                            found_target_url = True
                             step_result.message = \
                             f"Given more then one deployed host URL ({deployed_host_urls}) and target" \
                             f" substring ({target_substring}), selecting ({target_host_url}) for user" \
                             f" acceptance test (UAT)."
                             print(step_result.message)
-                    if not found_host_url:
+                    if not found_target_url:
                         step_result.message = \
                         f"Given more then one deployed host URL ({deployed_host_urls}) but no target" \
                         f" substring found, targeting first one ({target_host_url}) for user acceptance test (UAT)."

--- a/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
+++ b/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
@@ -134,14 +134,21 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
             target_substring = self.get_value('target-url-substring')
             if len(deployed_host_urls) > 1:
                 if target_substring:
+                    found_host_url = False
                     for deployed_host_url in deployed_host_urls:
                         if deployed_host_url.find(target_substring) != -1:
                             target_host_url = deployed_host_url
+                            found_host_url = True
                             step_result.message = \
                             f"Given more then one deployed host URL ({deployed_host_urls}) and target" \
                             f" substring ({target_substring}), selecting ({target_host_url}) for user" \
                             f" acceptance test (UAT)."
                             print(step_result.message)
+                    if not found_host_url:
+                        step_result.message = \
+                        f"Given more then one deployed host URL ({deployed_host_urls}) but no target" \
+                        f" substring found, targeting first one ({target_host_url}) for user acceptance test (UAT)."
+                        print(step_result.message)
                 else:
                     step_result.message = \
                     f"Given more then one deployed host URL ({deployed_host_urls}) but no target" \

--- a/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
+++ b/src/ploigos_step_runner/step_implementers/uat/maven_integration_test.py
@@ -124,12 +124,8 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
         """
         step_result = StepResult.from_step_implementer(self)
 
-        target_url_and_message = self.__get_target_host_url()
-        target_host_url = target_url_and_message[0]
-        message = target_url_and_message[1]
-        if message:
-            step_result.message = message
-            print(step_result.message)
+        # determine target url
+        target_host_url = self.__get_target_host_url(step_result)
 
         # run the tests
         print("Run user acceptance tests (UAT)")
@@ -171,14 +167,12 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
         # return result
         return step_result
 
-    def __get_target_host_url(self):
+    def __get_target_host_url(self, step_result):
         """Gets the URL to target for the UAT
 
         Returns
         -------
-        list
-            [0]str - host url to target
-            [1]str - message to print from step runner
+        str - host url to target
             """
         # NOTE:
         #   at some point may need to do smarter logic if a deployable has more then one deployed
@@ -196,19 +190,22 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
                     if deployed_host_url.find(target_substring) != -1:
                         target_host_url = deployed_host_url
                         found_target_url = True
-                        step_result_message = \
+                        step_result.message = \
                         f"Given more then one deployed host URL ({deployed_host_urls}) and target" \
                         f" substring ({target_substring}), selecting ({target_host_url}) for user" \
                         f" acceptance test (UAT)."
+                        print(step_result.message)
                 if not found_target_url:
-                    step_result_message = \
+                    step_result.message = \
                     f"Given more then one deployed host URL ({deployed_host_urls}) but no target" \
                     f" substring found, targeting first one ({target_host_url}) for user acceptance test (UAT)."
+                    print(step_result.message)
             elif len(deployed_host_urls) > 1:
                 target_host_url = deployed_host_urls[0]
-                step_result_message = \
+                step_result.message = \
                 f"Given more then one deployed host URL ({deployed_host_urls}) but no target" \
                 f" substring, targeting first one ({target_host_url}) for user acceptance test (UAT)."
+                print(step_result.message)
             else:
                 target_host_url = deployed_host_urls[0]
         elif deployed_host_urls:
@@ -216,7 +213,7 @@ class MavenIntegrationTest(MavenGeneric, MavenTestReportingMixin):
         else:
             target_host_url = self.get_value('target-host-url')
 
-        return (target_host_url, step_result_message)
+        return target_host_url
 
     def __get_test_report_dirs(self):
         """Gets the test report directory.

--- a/tests/step_implementers/uat/test_maven_integration_test.py
+++ b/tests/step_implementers/uat/test_maven_integration_test.py
@@ -231,6 +231,67 @@ class TestStepImplementerMavenIntegrationTest__run_step(
                 step_result=Any(StepResult),
                 test_report_dirs='/mock/test-results-dir'
             )
+    
+    def test_success_with_report_dir_deployed_host_urls_list_multiple_entries_target(
+        self,
+        mock_gather_evidence,
+        mock_get_test_report_dir,
+        mock_write_working_file,
+        mock_run_maven_step
+    ):
+        with TempDirectory() as test_dir:
+            # setup test
+            parent_work_dir_path = os.path.join(test_dir.path, 'working')
+            pom_file = os.path.join(test_dir.path, 'mock-pom.xml')
+            step_config = {
+                'pom-file': pom_file,
+                'target-host-url-maven-argument-name': 'mock.target-host-url-param',
+                'target-url-substring':'mock-app-2',
+                'deployed-host-urls': [
+                    'https://mock.ploigos.org/mock-app-1',
+                    'https://mock.ploigos.org/mock-app-2'
+                ]
+            }
+            step_implementer = self.create_step_implementer(
+                step_config=step_config,
+                parent_work_dir_path=parent_work_dir_path,
+            )
+
+            # run test
+            actual_step_result = step_implementer._run_step()
+
+            # verify results
+            expected_step_result = StepResult(
+                step_name='unit-test',
+                sub_step_name='MavenIntegrationTest',
+                sub_step_implementer_name='MavenIntegrationTest'
+            )
+            expected_step_result.message = \
+                f"Given more then one deployed host URL ({step_config['deployed-host-urls']}) " \
+                f"and target substring ({step_config['target-url-substring']}), selecting " \
+                f"(https://mock.ploigos.org/mock-app-2) for user acceptance test (UAT)."
+            expected_step_result.add_artifact(
+                description="Standard out and standard error from maven.",
+                name='maven-output',
+                value='/mock/mvn_output.txt'
+            )
+            expected_step_result.add_artifact(
+                description="Test report generated when running unit tests.",
+                name='test-report',
+                value='/mock/test-results-dir'
+            )
+            self.assertEqual(actual_step_result, expected_step_result)
+
+            mock_run_maven_step.assert_called_once_with(
+                mvn_output_file_path='/mock/mvn_output.txt',
+                step_implementer_additional_arguments=[
+                    '-Dmock.target-host-url-param=https://mock.ploigos.org/mock-app-2'
+                ]
+            )
+            mock_gather_evidence.assert_called_once_with(
+                step_result=Any(StepResult),
+                test_report_dirs='/mock/test-results-dir'
+            )
 
     def test_success_with_report_dir_deployed_host_urls_single(
         self,

--- a/tests/step_implementers/uat/test_maven_integration_test.py
+++ b/tests/step_implementers/uat/test_maven_integration_test.py
@@ -173,7 +173,7 @@ class TestStepImplementerMavenIntegrationTest__run_step(
                 test_report_dirs='/mock/test-results-dir'
             )
 
-    def test_success_with_report_dir_deployed_host_urls_list_multiple_entries(
+    def test_success_with_report_dir_deployed_host_urls_list_multiple_entries_no_target(
         self,
         mock_gather_evidence,
         mock_get_test_report_dir,
@@ -207,7 +207,7 @@ class TestStepImplementerMavenIntegrationTest__run_step(
                 sub_step_implementer_name='MavenIntegrationTest'
             )
             expected_step_result.message = \
-                f"Given more then one deployed host URL ({step_config['deployed-host-urls']})," \
+                f"Given more then one deployed host URL ({step_config['deployed-host-urls']}) but no target substring," \
                 f" targeting first one (https://mock.ploigos.org/mock-app-1) for user acceptance test (UAT)."
             expected_step_result.add_artifact(
                 description="Standard out and standard error from maven.",


### PR DESCRIPTION
# Purpose
Adding functionality to have the user specify a substring to pick a particular URL to target with UAT. Used at client.

NOTE: I put the get_target_host_url into its own function to make the linter happy, but I'm not actually sure that it made the code better. LMK if you have any other thoughts or suggestions.


# Breaking?
No


# Integration Testing

Tested with custom pipeline.


# Unit Test and Lint

[pr266_lint.txt](https://github.com/ploigos/ploigos-step-runner/files/8815537/pr266_lint.txt)
[pr266_unittests.txt](https://github.com/ploigos/ploigos-step-runner/files/8815538/pr266_unittests.txt)



