### PR TITLE
Enable asynchronous sync step and use wait to watch for sync completion

### DIFF
--- a/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
@@ -470,8 +470,14 @@ users:
                     argocd_output_buff
                 ])
 
+                # run app sync asynchronously and then wait for sync to finish
+                #
+                # NOTE: attempted work around for 'level=fatal msg=Operation
+                #       has completed with phase: Running' error
+                # SEE: https://github.com/argoproj/argo-cd/issues/5592
                 sh.argocd.app.sync(  # pylint: disable=no-member
                     *argocd_sync_additional_flags,
+                    '--async', #don't wait for sync to finish
                     '--timeout', argocd_sync_timeout_seconds,
                     '--retry-limit', argocd_sync_retry_limit,
                     argocd_app_name,
@@ -585,6 +591,7 @@ users:
                 ])
                 sh.argocd.app.wait(  # pylint: disable=no-member
                     argocd_app_name,
+                    '--sync',
                     '--health',
                     '--timeout', argocd_timeout_seconds,
                     _out=out_callback,

--- a/tests/step_implementers/shared/test_argocd_generic.py
+++ b/tests/step_implementers/shared/test_argocd_generic.py
@@ -1466,6 +1466,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
         )
         mock_argocd.app.sync.assert_called_once_with(
             '--prune',
+            '--async',
             '--timeout', 120,
             '--retry-limit', 3,
             'test',
@@ -1497,6 +1498,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
         )
         mock_argocd.app.sync.assert_called_once_with(
             '--prune',
+            '--async',
             '--timeout', 120,
             '--retry-limit', 4,
             'test',
@@ -1545,6 +1547,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
         )
         mock_argocd.app.sync.assert_called_once_with(
             '--prune',
+            '--async',
             '--timeout', 120,
             '--retry-limit', 3,
             'test',
@@ -1596,6 +1599,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
             argocd_timeout_seconds=120
         )
         mock_argocd.app.sync.assert_called_once_with(
+            '--async',
             '--timeout', 120,
             '--retry-limit', 3,
             'test',
@@ -1649,6 +1653,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
         mock_argocd.app.sync.assert_has_calls([
             call(
                 '--prune',
+                '--async',
                 '--timeout', 120,
                 '--retry-limit', 3,
                 'test',
@@ -1657,6 +1662,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
             ),
             call(
                 '--prune',
+                '--async',
                 '--timeout', 120,
                 '--retry-limit', 3,
                 'test',
@@ -1693,6 +1699,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
         )
         mock_argocd.app.sync.assert_called_once_with(
             '--prune',
+            '--async',
             '--timeout', 120,
             '--retry-limit', 3,
             'test',
@@ -1749,6 +1756,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_sync(TestStepImplementerS
             argocd_timeout_seconds=120
         )
         mock_argocd.app.sync.assert_called_once_with(
+            '--async',
             '--timeout', 120,
             '--retry-limit', 3,
             'test',
@@ -1829,6 +1837,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
         # validate
         mock_argocd.app.wait.assert_called_once_with(
             'mock-app',
+            '--sync',
             '--health',
             '--timeout', 42,
             _out=ANY,
@@ -1865,6 +1874,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
         mock_argocd.app.wait.assert_has_calls([
             call(
                 'mock-app',
+                '--sync',
                 '--health',
                 '--timeout', 42,
                 _out=ANY,
@@ -1872,6 +1882,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
             ),
             call(
                 'mock-app',
+                '--sync',
                 '--health',
                 '--timeout', 42,
                 _out=ANY,
@@ -1909,6 +1920,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
         mock_argocd.app.wait.assert_has_calls([
             call(
                 'mock-app',
+                '--sync',
                 '--health',
                 '--timeout', 42,
                 _out=ANY,
@@ -1916,6 +1928,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
             ),
             call(
                 'mock-app',
+                '--sync',
                 '--health',
                 '--timeout', 42,
                 _out=ANY,
@@ -1958,6 +1971,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_argocd_app_wait_for_health(
         # validate
         mock_argocd.app.wait.assert_called_once_with(
             'mock-app',
+            '--sync',
             '--health',
             '--timeout', 42,
             _out=ANY,


### PR DESCRIPTION
# Purpose

<!--
Please describe the purpose of this pull request.
If for an enhancment please go beyond just saying "adding fuctionality X" and add a reason/use case for the functionality.
-->
In order to provide a working solution around this argocd cli upstream [issue](https://github.com/argoproj/argo-cd/issues/5592), we've changed the app sync to be asynchronous and then used the following wait to watch for the sync to complete.

# Breaking?
No, the workflow was breaking prior to this fix.

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
<!--
If you spent the time to do some integration testing please link to the pipelines/workflows demonstrating this functionality in context.
-->
Example successful workflows -
https://github.com/ploigos/spring-petclinic/actions
https://github.com/ploigos/java-github-example/actions

<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
