### PR TITLE
Add integration test to pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,9 +65,7 @@ jobs:
           OPENSHIFT_URL: ${{ secrets.OPENSHIFT_URL }}
           OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
           OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
+          PSR_BRANCH: ${{ github.ref }}
         run: |
-          echo "${{ github.ref }}"
-          export PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doesn't work with branch names like feature/something/anotherthing.
-          echo ${PSR_BRANCH}
           ./tests/integration/run-integration-tests.sh
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,12 +56,14 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
-    env:
-      OPENSHIFT_URL: ${{ secrets.OPENSHIFT_URL }}
-      OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
-      OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
-    run: |
-      PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doens't work with branch names like feature/something/anotherthing.
-      echo ${PSR_BRANCH}
-      ./tests/integration/run-integration-tests.sh
+    steps:
+      - name: Integration Tests
+        env:
+          OPENSHIFT_URL: ${{ secrets.OPENSHIFT_URL }}
+          OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
+          OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
+        run: |
+          PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doens't work with branch names like feature/something/anotherthing.
+          echo ${PSR_BRANCH}
+          ./tests/integration/run-integration-tests.sh
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -56,6 +56,9 @@ jobs:
 
   integration-test:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -57,13 +57,16 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+
       - name: Integration Tests
         env:
           OPENSHIFT_URL: ${{ secrets.OPENSHIFT_URL }}
           OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
           OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
         run: |
-          PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doens't work with branch names like feature/something/anotherthing.
+          PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doesn't work with branch names like feature/something/anotherthing.
           echo ${PSR_BRANCH}
           ./tests/integration/run-integration-tests.sh
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -66,7 +66,8 @@ jobs:
           OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
           OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
         run: |
-          PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doesn't work with branch names like feature/something/anotherthing.
+          echo "${{ github.ref }}"
+          export PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doesn't work with branch names like feature/something/anotherthing.
           echo ${PSR_BRANCH}
           ./tests/integration/run-integration-tests.sh
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,9 +29,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2
@@ -56,3 +53,15 @@ jobs:
         name: Python ${{ matrix.python-version }}
         env_vars: PYTHON
         fail_ci_if_error: true
+
+  integration-test:
+    runs-on: ubuntu-latest
+    env:
+      OPENSHIFT_URL: ${{ secrets.OPENSHIFT_URL }}
+      OPENSHIFT_USER: ${{ secrets.OPENSHIFT_USER }}
+      OPENSHIFT_PASSWORD: ${{ secrets.OPENSHIFT_PASSWORD }}
+    run: |
+      PSR_BRANCH=$(echo "${{ github.ref }}" | awk -F '/' '{$1=$2=""; if($4) print($3 "/" $4); else print($3)}') # Hack to get the branch name. Doens't work with branch names like feature/something/anotherthing.
+      echo ${PSR_BRANCH}
+      ./tests/integration/run-integration-tests.sh
+

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,1 @@
+everything-pipelinerun.yml

--- a/tests/integration/everything-pipelinerun-template.yml
+++ b/tests/integration/everything-pipelinerun-template.yml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: psr-it-everything-
+  labels:
+    app.kubernetes.io/component: ploigos-workflow
+    app.kubernetes.io/instance: everything-pipeline
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: service2
+    app.kubernetes.io/part-of: app1
+    helm.sh/chart: ploigos-workflow-tekton-resources-0.22.1-edge.0
+spec:
+  params:
+    - name: verbose
+      value: "true"
+    - name: appRepoUrl
+      value: http://gitea.devsecops.svc.cluster.local:3000/platform/reference-quarkus-mvn
+    - name: appRepoRef
+      value: main
+    - name: stepRunnerConfigDir
+      value: /opt/platform-config/ /opt/platform-config-secrets/ cicd/ploigos-software-factory-operator/ploigos-step-runner-config/
+    - name: pgpKeysSecretName
+      value: ploigos-gpg-key
+    - name: stepRunnerPackageName
+      value: ploigos-step-runner
+    - name: stepRunnerUpdateLibrary
+      value: "true"
+    - name: stepRunnerLibIndexUrl
+      value: https://pypi.org/simple/
+    - name: stepRunnerLibExtraIndexUrl
+      value: https://pypi.org/simple/
+    - name: stepRunnerLibSourceUrl
+      value: STEP_RUNNER_LIB_SOURCE_URL
+    - name: envNameDev
+      value: DEV
+    - name: envNameTest
+      value: TEST
+    - name: envNameProd
+      value: PROD
+    - name: ciOnlyGitRefPatterns
+      value: ^$
+    - name: devGitRefPatterns
+      value: ^feature/.+$|^PR-.+$
+    - name: releaseGitRefPatterns
+      value: ^main$
+    - name: workflowWorkerImageDefault
+      value: quay.io/ploigos/ploigos-tool-maven:latest
+    - name: workflowWorkerImageSourceClone
+      value: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.12.1
+    - name: workflowWorkerImageUnitTest
+      value: quay.io/ploigos/ploigos-tool-maven:latest
+    - name: workflowWorkerImagePackage
+      value: quay.io/ploigos/ploigos-tool-maven:latest
+    - name: workflowWorkerImageStaticCodeAnalysis
+      value: quay.io/ploigos/ploigos-tool-sonar:latest
+    - name: workflowWorkerImagePushArtifacts
+      value: quay.io/ploigos/ploigos-tool-maven:latest
+    - name: workflowWorkerImageContainerOperations
+      value: ploigos/ploigos-tool-containers:latest
+    - name: workflowWorkerImageContainerImageStaticComplianceScan
+      value: ploigos/ploigos-tool-openscap:latest
+    - name: workflowWorkerImageContainerImageStaticVulnerabilityScan
+      value: ploigos/ploigos-tool-openscap:latest
+    - name: workflowWorkerImageDeploy
+      value: ploigos/ploigos-tool-argocd:latest
+    - name: workflowWorkerImageValidateEnvironmentConfiguration
+      value: ploigos/ploigos-tool-config-lint:latest
+    - name: workflowWorkerImageUAT
+      value: quay.io/ploigos/ploigos-tool-maven:latest
+    - name: workflowWorkerImageAutoGov
+      value: ploigos/ploigos-tool-autogov:latest
+  pipelineRef:
+    name: app1-service1
+  resources: []
+  serviceAccountName: pipeline
+  workspaces:
+    - name: home
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 10Gi
+    - name: app
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - configMap:
+        name: ploigos-platform-config-demo
+      name: ploigos-platform-config
+    - name: ploigos-platform-config-secrets
+      secret:
+        secretName: ploigos-platform-config-secrets-demo

--- a/tests/integration/everything-pipelinerun-template.yml
+++ b/tests/integration/everything-pipelinerun-template.yml
@@ -5,10 +5,6 @@ metadata:
   labels:
     app.kubernetes.io/component: ploigos-workflow
     app.kubernetes.io/instance: everything-pipeline
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: service2
-    app.kubernetes.io/part-of: app1
-    helm.sh/chart: ploigos-workflow-tekton-resources-0.22.1-edge.0
 spec:
   params:
     - name: verbose

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -25,7 +25,7 @@ CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n ${PIPELINE_NAME
 STATUS=Unknown
 while [ "${STATUS}" == "Unknown" ]; do
     sleep ${STATUS_CHECK_WAIT_SEC}
-    CONDITIONS=$(oc get ${CREATED_PIPELINERUN} -o yaml | yq .status.conditions)
+    CONDITIONS=$(oc get ${CREATED_PIPELINERUN} -n ${PIPELINE_NAMESPACE} -o yaml | yq .status.conditions)
     STATUS=$(echo "${CONDITIONS}" | yq .[0].status)
     if [ "${STATUS}" == "Unknown" ]; then
         sleep ${STATUS_CHECK_WAIT_SEC}

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -18,7 +18,7 @@ sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-
 
 # Create the PipelineRun
 oc login --server=${OPENSHIFT_URL} -u ${OPENSHIFT_USER} -p ${OPENSHIFT_PASSWORD}
-CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n "${PIPELINE_NAMESPACE} | cut -d ' ' -f 1)
+CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n ${PIPELINE_NAMESPACE}" | cut -d ' ' -f 1)
 
 # Wait for the pipeline to finish
 STATUS=Unknown

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -7,10 +7,12 @@ set -eux -o pipefail
 # OPENSHIFT_USER - The user for `oc login`
 # OPENSHIFT_PASSWORD - The password for `oc login`
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 STEP_RUNNER_LIB_SOURCE_URL="git+https://github.com/ploigos/ploigos-step-runner.git@${PSR_BRANCH}"
 
 # Generate the Tekton PipelineRun
-cp everything-pipelinerun-template.yml everything-pipelinerun.yml
+cp ${SCRIPT_DIR}=everything-pipelinerun-template.yml everything-pipelinerun.yml
 sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-pipelinerun.yml
 
 # Create the PipelineRun

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 STEP_RUNNER_LIB_SOURCE_URL="git+https://github.com/ploigos/ploigos-step-runner.git@${PSR_BRANCH}"
 
 # Generate the Tekton PipelineRun
-cp ${SCRIPT_DIR}=everything-pipelinerun-template.yml everything-pipelinerun.yml
+cp ${SCRIPT_DIR}/everything-pipelinerun-template.yml everything-pipelinerun.yml
 sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-pipelinerun.yml
 
 # Create the PipelineRun

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -10,6 +10,7 @@ set -eux -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 STEP_RUNNER_LIB_SOURCE_URL="git+https://github.com/ploigos/ploigos-step-runner.git@${PSR_BRANCH}"
+PIPELINE_NAMESPACE=devsecops
 
 # Generate the Tekton PipelineRun
 cp ${SCRIPT_DIR}/everything-pipelinerun-template.yml everything-pipelinerun.yml
@@ -17,7 +18,7 @@ sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-
 
 # Create the PipelineRun
 oc login --server=${OPENSHIFT_URL} -u ${OPENSHIFT_USER} -p ${OPENSHIFT_PASSWORD}
-CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml | cut -d ' ' -f 1)
+CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n "${PIPELINE_NAMESPACE} | cut -d ' ' -f 1)
 
 # Wait for the pipeline to finish
 STATUS=Unknown

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 STEP_RUNNER_LIB_SOURCE_URL="git+https://github.com/ploigos/ploigos-step-runner.git@${PSR_BRANCH}"
 PIPELINE_NAMESPACE=devsecops
+STATUS_CHECK_WAIT_SEC=60
 
 # Generate the Tekton PipelineRun
 cp ${SCRIPT_DIR}/everything-pipelinerun-template.yml everything-pipelinerun.yml
@@ -23,11 +24,11 @@ CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n ${PIPELINE_NAME
 # Wait for the pipeline to finish
 STATUS=Unknown
 while [ "${STATUS}" == "Unknown" ]; do
-    sleep 5
+    sleep ${STATUS_CHECK_WAIT_SEC}
     CONDITIONS=$(oc get ${CREATED_PIPELINERUN} -o yaml | yq .status.conditions)
     STATUS=$(echo "${CONDITIONS}" | yq .[0].status)
     if [ "${STATUS}" == "Unknown" ]; then
-        sleep 60
+        sleep ${STATUS_CHECK_WAIT_SEC}
     fi
 done
 

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -18,7 +18,7 @@ sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-
 
 # Create the PipelineRun
 oc login --server=${OPENSHIFT_URL} -u ${OPENSHIFT_USER} -p ${OPENSHIFT_PASSWORD}
-CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n ${PIPELINE_NAMESPACE}" | cut -d ' ' -f 1)
+CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml -n ${PIPELINE_NAMESPACE} | cut -d ' ' -f 1)
 
 # Wait for the pipeline to finish
 STATUS=Unknown

--- a/tests/integration/run-integration-tests.sh
+++ b/tests/integration/run-integration-tests.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eux -o pipefail
+
+# This script assumes the following environment variables are set:
+# PSR_BRANCH - the branch to test
+# OPENSHIFT_URL - The K8s API URL for the cluster to run the tekton pipeline in
+# OPENSHIFT_USER - The user for `oc login`
+# OPENSHIFT_PASSWORD - The password for `oc login`
+
+STEP_RUNNER_LIB_SOURCE_URL="git+https://github.com/ploigos/ploigos-step-runner.git@${PSR_BRANCH}"
+
+# Generate the Tekton PipelineRun
+cp everything-pipelinerun-template.yml everything-pipelinerun.yml
+sed -i "s,STEP_RUNNER_LIB_SOURCE_URL,${STEP_RUNNER_LIB_SOURCE_URL}," everything-pipelinerun.yml
+
+# Create the PipelineRun
+oc login --server=${OPENSHIFT_URL} -u ${OPENSHIFT_USER} -p ${OPENSHIFT_PASSWORD}
+CREATED_PIPELINERUN=$(oc create -f everything-pipelinerun.yml | cut -d ' ' -f 1)
+
+# Wait for the pipeline to finish
+STATUS=Unknown
+while [ "${STATUS}" == "Unknown" ]; do
+    sleep 5
+    CONDITIONS=$(oc get ${CREATED_PIPELINERUN} -o yaml | yq .status.conditions)
+    STATUS=$(echo "${CONDITIONS}" | yq .[0].status)
+    if [ "${STATUS}" == "Unknown" ]; then
+        sleep 60
+    fi
+done
+
+# Report success or failure
+if [ "${STATUS}" != "True" ]; then
+    echo Tekton Everything Pipeline Failed
+    echo Integration Tests Failed
+    exit 1
+fi
+echo Tekton Everything Pipeline Passed
+echo Integration Tests Passed
+


### PR DESCRIPTION
# Purpose
This kicks off a tekton everything pipeline with every commit to an open PR and gates the pr on that passing.

They're hosted in an RHPDS cluster that we'll have to recreate like every week.

Previous runs get cancelled on a new push ... but the underlying Tekton run keeps going because there's no good way to cancel it. So please don't push 100 commits in an hour :)

# Breaking?
No

# Integration Testing
This is that