### PR TITLE
Disable broken 3.6 linting (and unit tests)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2


### PR DESCRIPTION
# Purpose

The CI/CD build for the main branch fails because pylint on 3.6 fails. This is new. The code didn't change. Presumably pylint or something else changed.

Let's turn it off to get a green main branch pipeline and go from there.

**Short term fix:** Disable linting & unit tests for 3.6.

**Long term fix:** Probably drop testing for 3.6, but **upgrade the ploigos base images to not use 3.6 first**. Python 3.7 has been out for 4 years now.

# Breaking?
No, but if there's a 3.6 specific bug we might miss it, so don't do this for long.
