### PR TITLE
Quick fix to ignore case when deciding whether to obfuscate config keys

### DIFF
--- a/src/ploigos_step_runner/config/decryptors/obfuscation_defaults.py
+++ b/src/ploigos_step_runner/config/decryptors/obfuscation_defaults.py
@@ -20,7 +20,7 @@ class ObfuscationDefaults(ConfigValueDecryptor):
 
     def can_decrypt(self, config_value):
         for path_part in config_value.path_parts:
-            if re.search(".*(password|username).*", str(path_part)):
+            if re.search(".*(password|username).*", str(path_part), re.IGNORECASE):
                 return True
         return False
 

--- a/tests/config/decryptors/test_obfuscation_defaults.py
+++ b/tests/config/decryptors/test_obfuscation_defaults.py
@@ -45,6 +45,20 @@ class TestObfuscationDefaults(TestCase):
         # THEN it should be obfuscated
         self.assertFalse(actual_result)
 
+
+    def test_can_decrypt_mixed_case(self):
+        # GIVEN an ObfuscationDefaults
+        obfuscation_defaults = ObfuscationDefaults()
+
+        # GIVEN a ConfigValue that is a password
+        config_value = self.config_value_like("admin-PASSword-for-tool", "abc123")
+
+        # WHEN I test if a password should be obfuscated
+        actual_result = obfuscation_defaults.can_decrypt(config_value)
+
+        # THEN it should be obfuscated
+        self.assertTrue(actual_result)
+
     def test_decrypt(self):
         # GIVEN ObfuscationDefaults
         obfuscation_defaults = ObfuscationDefaults()


### PR DESCRIPTION
Previously if a config key was "my-password" the value would automatically be obfuscated, but if it was "my-Password", it would not. This PR fixes that.