### PR TITLE
ci - adds ability to manually trigger the "push-main" ci workflow

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -3,6 +3,7 @@ name: Publish Dev
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   lint:


### PR DESCRIPTION
# Purpose

add ability to manually trigger the main branch ci workflow.

# Breaking?
No

# Integration Testing
N/A
