### PR TITLE
adding fail on shared resource flag to argocd

### DIFF
--- a/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
+++ b/src/ploigos_step_runner/step_implementers/deploy/argocd_deploy.py
@@ -17,6 +17,13 @@ Configuration Key                       | Required? | Default  | Description
 `argocd-auto-sync`                      | Yes       | True     | If set to false, argo cd will sync only if \
                                                                  explicitly told to do so via the UI or CLI. \
                                                                  Otherwise it will sync if the repo contents have changed.
+`argocd-fail-on-shared-resource`        | Yes       | False    | If set to false, argo cd will apply all manifests \
+                                                                 found in the git path configured in the Application \
+                                                                 regardless if the resources defined in the yamls are \
+                                                                 already applied by another Application. \
+                                                                 Otherwise it will fail the sync whenever it finds a \
+                                                                 resource in the current Application that is already \
+                                                                 applied in the cluster by another Application.
 `argocd-skip-tls`                       | Yes       | False    | `False` to not ignore TLS issues when \
                                                                   authenticating with ArgoCD. True` to ignore TLS \
                                                                   issues when authenticating with ArgoCD.
@@ -129,6 +136,7 @@ DEFAULT_CONFIG = {
     'argocd-sync-timeout-seconds': 60,
     'argocd-sync-retry-limit': 3,
     'argocd-auto-sync': True,
+    'argocd-fail-on-shared-resource': False,
     'argocd-skip-tls' : False,
     'argocd-sync-prune': True,
     'argocd-project': 'default',
@@ -377,6 +385,7 @@ class ArgoCDDeploy(ContainerDeployMixin, ArgoCDGeneric):
                 dest_server=deployment_config_destination_cluster_uri,
                 dest_namespace=deployment_namespace,
                 auto_sync=self.get_value('argocd-auto-sync'),
+                fail_on_shared_resource=self.get_value('argocd-fail-on-shared-resource'),
                 values_files=argocd_values_files,
                 project=self.get_value('argocd-project')
             )

--- a/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
@@ -394,6 +394,7 @@ users:
         dest_server,
         dest_namespace,
         auto_sync,
+        fail_on_shared_resource,
         values_files
     ):
         """Creates or updates an ArgoCD App.
@@ -408,6 +409,11 @@ users:
                 sync_policy = 'automated'
             else:
                 sync_policy = 'none'
+            
+            if str(fail_on_shared_resource).lower() == 'true':
+                sync_option = 'FailOnSharedResource=true'
+            else:
+                sync_option = 'FailOnSharedResource=false'
 
             values_params = None
             if values_files:
@@ -423,6 +429,7 @@ users:
                 f'--dest-server={dest_server}',
                 f'--dest-namespace={dest_namespace}',
                 f'--sync-policy={sync_policy}',
+                f'--sync-option={sync_option}',
                 f'--project={project}',
                 values_params,
                 '--upsert',

--- a/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
+++ b/src/ploigos_step_runner/step_implementers/shared/argocd_generic.py
@@ -409,7 +409,7 @@ users:
                 sync_policy = 'automated'
             else:
                 sync_policy = 'none'
-            
+
             if str(fail_on_shared_resource).lower() == 'true':
                 sync_option = 'FailOnSharedResource=true'
             else:

--- a/tests/step_implementers/deploy/test_argocd_deploy.py
+++ b/tests/step_implementers/deploy/test_argocd_deploy.py
@@ -609,6 +609,7 @@ class TestStepImplementerArgoCDDeploy_run_step(TestStepImplementerDeployArgoCDBa
                 dest_server='https://kubernetes.default.svc',
                 dest_namespace='test-app-name',
                 auto_sync=True,
+                fail_on_shared_resource=False,
                 values_files=['values-PROD.yaml'],
                 project='default'
             )
@@ -761,6 +762,7 @@ class TestStepImplementerArgoCDDeploy_run_step(TestStepImplementerDeployArgoCDBa
                 dest_server='https://kubernetes.default.svc',
                 dest_namespace='test-app-name',
                 auto_sync=True,
+                fail_on_shared_resource=False,
                 values_files=['values-PROD.yaml'],
                 project='default'
             )
@@ -916,6 +918,7 @@ class TestStepImplementerArgoCDDeploy_run_step(TestStepImplementerDeployArgoCDBa
                 dest_server='https://kubernetes.default.svc',
                 dest_namespace='best-namespace',
                 auto_sync=True,
+                fail_on_shared_resource=False,
                 values_files=['values-PROD.yaml'],
                 project='default'
             )
@@ -1070,6 +1073,7 @@ class TestStepImplementerArgoCDDeploy_run_step(TestStepImplementerDeployArgoCDBa
                 dest_server='https://kubernetes.default.svc',
                 dest_namespace='test-app-name',
                 auto_sync=True,
+                fail_on_shared_resource=False,
                 values_files=['values-PROD.yaml', 'secrets.yaml', 'extra-secrets.yaml'],
                 project='default'
             )

--- a/tests/step_implementers/deploy/test_argocd_deploy.py
+++ b/tests/step_implementers/deploy/test_argocd_deploy.py
@@ -43,6 +43,7 @@ class TestStepImplementerSharedArgoCDDeploy_Other(TestStepImplementerDeployArgoC
             'argocd-auto-sync': True,
             'argocd-skip-tls' : False,
             'argocd-sync-prune': True,
+            'argocd-fail-on-shared-resource': False,
             'argocd-project': 'default',
             'deployment-config-helm-chart-path': './',
             'deployment-config-helm-chart-additional-values-files': [],

--- a/tests/step_implementers/shared/test_argocd_generic.py
+++ b/tests/step_implementers/shared/test_argocd_generic.py
@@ -1234,6 +1234,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
         dest_server = 'https://kubernetes.default.svc'
         dest_namespace = 'my-namespace'
         auto_sync = True
+        fail_on_shared_resource = False
         values_files = []
         ArgoCDGeneric._argocd_app_create_or_update(
             argocd_app_name=argocd_app_name,
@@ -1244,10 +1245,12 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             dest_server=dest_server,
             dest_namespace=dest_namespace,
             auto_sync=auto_sync,
+            fail_on_shared_resource=fail_on_shared_resource,
             values_files=values_files
         )
 
         sync_policy = 'automated'
+        sync_option = 'FailOnSharedResource=false'
         values_params = None
         mock_argocd.app.create.assert_called_once_with(
             argocd_app_name,
@@ -1257,6 +1260,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             f'--dest-server={dest_server}',
             f'--dest-namespace={dest_namespace}',
             f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
             f'--project={project}',
             values_params,
             '--upsert',
@@ -1274,6 +1278,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
         dest_server = 'https://kubernetes.default.svc'
         dest_namespace = 'my-namespace'
         auto_sync = False
+        fail_on_shared_resource = False
         values_files = []
         ArgoCDGeneric._argocd_app_create_or_update(
             argocd_app_name=argocd_app_name,
@@ -1284,10 +1289,12 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             dest_server=dest_server,
             dest_namespace=dest_namespace,
             auto_sync=auto_sync,
+            fail_on_shared_resource=fail_on_shared_resource,
             values_files=values_files
         )
 
         sync_policy = 'none'
+        sync_option = 'FailOnSharedResource=false'
         values_params = None
         mock_argocd.app.create.assert_called_once_with(
             argocd_app_name,
@@ -1297,6 +1304,51 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             f'--dest-server={dest_server}',
             f'--dest-namespace={dest_namespace}',
             f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
+            f'--project={project}',
+            values_params,
+            '--upsert',
+            _out=ANY,
+            _err=ANY
+        )
+    
+    @patch('sh.argocd', create=True)
+    def testargocd_app_create_or_update_success_sync_none_fail_on_shared_true_no_extra_values_files(self, mock_argocd):
+        argocd_app_name = 'test'
+        project = 'myproject'
+        repo = 'https://git.test.xyz'
+        revision = 'feature/test'
+        path = 'charts/awesome'
+        dest_server = 'https://kubernetes.default.svc'
+        dest_namespace = 'my-namespace'
+        auto_sync = False
+        fail_on_shared_resource = True
+        values_files = []
+        ArgoCDGeneric._argocd_app_create_or_update(
+            argocd_app_name=argocd_app_name,
+            project=project,
+            repo=repo,
+            revision=revision,
+            path=path,
+            dest_server=dest_server,
+            dest_namespace=dest_namespace,
+            auto_sync=auto_sync,
+            fail_on_shared_resource=fail_on_shared_resource,
+            values_files=values_files
+        )
+
+        sync_policy = 'none'
+        sync_option = 'FailOnSharedResource=true'
+        values_params = None
+        mock_argocd.app.create.assert_called_once_with(
+            argocd_app_name,
+            f'--repo={repo}',
+            f'--revision={revision}',
+            f'--path={path}',
+            f'--dest-server={dest_server}',
+            f'--dest-namespace={dest_namespace}',
+            f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
             f'--project={project}',
             values_params,
             '--upsert',
@@ -1314,6 +1366,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
         dest_server = 'https://kubernetes.default.svc'
         dest_namespace = 'my-namespace'
         auto_sync = True
+        fail_on_shared_resource = False
         values_files = ['values-foo.yaml']
         ArgoCDGeneric._argocd_app_create_or_update(
             argocd_app_name=argocd_app_name,
@@ -1324,10 +1377,12 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             dest_server=dest_server,
             dest_namespace=dest_namespace,
             auto_sync=auto_sync,
+            fail_on_shared_resource=fail_on_shared_resource,
             values_files=values_files
         )
 
         sync_policy = 'automated'
+        sync_option = 'FailOnSharedResource=false'
         values_params = ['--values=values-foo.yaml']
         mock_argocd.app.create.assert_called_once_with(
             argocd_app_name,
@@ -1337,6 +1392,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             f'--dest-server={dest_server}',
             f'--dest-namespace={dest_namespace}',
             f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
             f'--project={project}',
             values_params,
             '--upsert',
@@ -1354,6 +1410,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
         dest_server = 'https://kubernetes.default.svc'
         dest_namespace = 'my-namespace'
         auto_sync = True
+        fail_on_shared_resource = False
         values_files = ['values-foo.yaml', 'values-DEV.yaml']
         ArgoCDGeneric._argocd_app_create_or_update(
             argocd_app_name=argocd_app_name,
@@ -1364,10 +1421,12 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             dest_server=dest_server,
             dest_namespace=dest_namespace,
             auto_sync=auto_sync,
+            fail_on_shared_resource=fail_on_shared_resource,
             values_files=values_files
         )
 
         sync_policy = 'automated'
+        sync_option = 'FailOnSharedResource=false'
         values_params = ['--values=values-foo.yaml', '--values=values-DEV.yaml']
         mock_argocd.app.create.assert_called_once_with(
             argocd_app_name,
@@ -1377,6 +1436,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             f'--dest-server={dest_server}',
             f'--dest-namespace={dest_namespace}',
             f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
             f'--project={project}',
             values_params,
             '--upsert',
@@ -1398,6 +1458,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
         dest_server = 'https://kubernetes.default.svc'
         dest_namespace = 'my-namespace'
         auto_sync = True
+        fail_on_shared_resource = False
         values_files = ['values-foo.yaml']
 
         with self.assertRaisesRegex(
@@ -1421,10 +1482,12 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
                 dest_server=dest_server,
                 dest_namespace=dest_namespace,
                 auto_sync=auto_sync,
+                fail_on_shared_resource=fail_on_shared_resource,
                 values_files=values_files
             )
 
         sync_policy = 'automated'
+        sync_option = 'FailOnSharedResource=false'
         values_params = ['--values=values-foo.yaml']
         mock_argocd.app.create.assert_called_once_with(
             argocd_app_name,
@@ -1434,6 +1497,7 @@ class TestStepImplementerSharedArgoCDGenericArgoCD_app_create_or_update(TestStep
             f'--dest-server={dest_server}',
             f'--dest-namespace={dest_namespace}',
             f'--sync-policy={sync_policy}',
+            f'--sync-option={sync_option}',
             f'--project={project}',
             values_params,
             '--upsert',


### PR DESCRIPTION
# Purpose

<!--
Adding FailOnSharedResource sync option. By default, ArgoCD will apply all manifests found in the git path configured in the Application regardless if the resources defined in the yamls are already applied by another Application. If the FailOnSharedResource sync option is set, ArgoCD will fail the sync whenever it finds a resource in the current Application that is already applied in the cluster by another Application
-->
Adding FailOnSharedResource sync option. By default, ArgoCD will apply all manifests found in the git path configured in the Application regardless if the resources defined in the yamls are already applied by another Application. If the FailOnSharedResource sync option is set, ArgoCD will fail the sync whenever it finds a resource in the current Application that is already applied in the cluster by another Application

# Breaking?
No

<!-- If YES, uncomment this
## Whats Breaking and why?
-->
<!--
If this change breaks anything, whether by removing functionality/api or changing the default behavior/configuraiton of existing fucntionality/api,
then please list out what will break and why its worth it.
-->

# Integration Testing
<!--
Added to existing tests for argocd
-->
Added to existing tests for argocd
<!-- Example
* [Everything]()
* [Typical]()
* [Minimal]()
-->
