### PR TITLE
Fix errors due to python & sh module versions

### DIFF
--- a/.github/workflows/push-main.yml
+++ b/.github/workflows/push-main.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python 🐍
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
 
     - name: Install tox 🧰
       run: |

--- a/.github/workflows/push-tag.yml
+++ b/.github/workflows/push-tag.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     steps:
     - name: Checkout 🛎️
       uses: actions/checkout@v2
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Python 🐍
       uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.7'
 
     - name: Install tox 🧰
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe: False
 install_requires =
   PyYAML
   gitpython
-  sh ==1.14.3
+  sh ==1.14.2
   jinja2
   prometheus_client
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ zip_safe: False
 install_requires =
   PyYAML
   gitpython
-  sh
+  sh ==1.14.3
   jinja2
   prometheus_client
 


### PR DESCRIPTION
Two things were needed to fix this:

1. The sh module was not version locked. There was a breaking api change. We went back to a working version.
2. We previously had dropped support for python 3.6 and removed *most* uses of it in the GitHub workflow definitions, but missed some. This removes them. Really this time. And yes, we still need to upgrade python in ploigos-base because it uses python 3.6.