### PR TITLE
Add mvn note to development/test section in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ step-runner-results
 step-runner-working
 results.yml/
 .venvs
+.venv
 
 # Eclipse
 .project

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ python -m pip install -e '.[tests]'
 ```
 
 ### Run Tests
+
+> :note: Some tests require `mvn` command in your PATH. Install with brew/yum/dnf prior to running tests.
+
 ```bash
 tox -e test
 ```

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ python -m pip install --upgrade pip
 python -m pip install -e '.[tests]'
 ```
 
-### Run Tests
-
 > :notebook: Some tests require `mvn` command in your PATH. Install with brew/yum/dnf prior to running tests.
+
+### Run Tests
 
 ```bash
 tox -e test

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python -m pip install -e '.[tests]'
 
 ### Run Tests
 
-> :note: Some tests require `mvn` command in your PATH. Install with brew/yum/dnf prior to running tests.
+> :notebook: Some tests require `mvn` command in your PATH. Install with brew/yum/dnf prior to running tests.
 
 ```bash
 tox -e test


### PR DESCRIPTION
# Purpose

Project should call out that mvn is required in development setup.

Following dev setup instructions and running `tox test` will result in an error for `tests/step_implementers/generate_metadata/test_maven_generate_metadata.py::TestStepImplementerMavenGenerateMetadata::test_run_step_pass` if the `mvn` command isn't available.

```
E       sh.CommandNotFound: mvn

.venv/lib/python3.9/site-packages/sh.py:3457: CommandNotFound
```

Might save somebody time troubleshooting 🤷

# Breaking?

No